### PR TITLE
Replaced incompatible emojis in docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,8 +41,8 @@ packages.
 | Optim                    | ✅                        | ✅                        | ✅                        | ✅                        | ✅                        | ✅                        |
 | QuadDIRECT               |                        ❌ |                        ❌ |                        ❌ |                        ❌ | ✅                        |                        ❌ |
 
-✅                  = supported
+✅ = supported
 
-🟡                = supported in downstream library but not yet implemented in `GalacticOptim`; PR to add this functionality are welcome
+🟡 = supported in downstream library but not yet implemented in `GalacticOptim`; PR to add this functionality are welcome
 
-                       ❌ = not supported
+❌ = not supported


### PR DESCRIPTION
Sorry for the repeated PR about the docs. I just noticed the emoji for the optimizer table render normally in the md files on github but don't work with `Documenter.jl`. So I replaced them with unicode characters.