### PR TITLE
Update docs for MathOptInterface wrapper

### DIFF
--- a/docs/src/optimization_packages/mathoptinterface.md
+++ b/docs/src/optimization_packages/mathoptinterface.md
@@ -46,19 +46,6 @@ sol = solve(prob,  Ipopt.Optimizer(); option_name = option_value, ...)
   `Optimization.MOI.OptimizerWithAttributes(KNITRO.Optimizer, "option_name" => option_value, ...)`
 - The full list of optimizer options can be found in the [KNITRO Documentation](https://www.artelys.com/docs/knitro//3_referenceManual/callableLibraryAPI.html)
 
-#### AmplNLWriter.jl (MathOptInterface)
-
-- [`AmplNLWriter.Optimizer`](https://github.com/jump-dev/AmplNLWriter.jl)
-- AmplNLWriter is a MathOptInterface optimizer, and thus its options are handled via
-  `Optimization.MOI.OptimizerWithAttributes(AmplNLWriter.Optimizer(algname), "option_name" => option_value, ...)`
-- Possible `algname`s are:
-    * `Bonmin_jll.amplexe`
-    * `Couenne_jll.amplexe`
-    * `Ipopt_jll.amplexe`
-    * `SHOT_jll.amplexe`
-
-To use one of the JLLs, they must be added first. For example: `Pkg.add("Bonmin_jll")`.
-
 #### Juniper.jl (MathOptInterface)
 
 - [`Juniper.Optimizer`](https://github.com/lanl-ansi/Juniper.jl)
@@ -85,15 +72,6 @@ opt = Optimization.MOI.OptimizerWithAttributes(optimizer, "nl_solver"=>nl_solver
 sol = solve(prob, opt)
 ```
 
-
-## BARON.jl (MathOptInterface)
-
-- [`BARON.Optimizer`](https://github.com/joehuchette/BARON.jl)
-- BARON is a MathOptInterface optimizer, and thus its options are handled via
-  `Optimization.MOI.OptimizerWithAttributes(BARON.Optimizer, "option_name" => option_value, ...)`
-- The full list of optimizer options can be found in the [BARON Documentation](https://minlp.com/baron-solver)
-
-
 ### Gradient-Based
 #### Ipopt.jl (MathOptInterface)
 
@@ -101,14 +79,3 @@ sol = solve(prob, opt)
 - Ipopt is a MathOptInterface optimizer, and thus its options are handled via
   `Optimization.MOI.OptimizerWithAttributes(Ipopt.Optimizer, "option_name" => option_value, ...)`
 - The full list of optimizer options can be found in the [Ipopt Documentation](https://coin-or.github.io/Ipopt/OPTIONS.html#OPTIONS_REF)
-
-
-## Global Optimizer
-
-### With Constraint Equations
-#### Alpine.jl (MathOptInterface)
-
-- [`Alpine.Optimizer`](https://github.com/lanl-ansi/Alpine.jl)
-- Alpine is a MathOptInterface optimizer, and thus its options are handled via
-  `Optimization.MOI.OptimizerWithAttributes(Alpine.Optimizer, "option_name" => option_value, ...)`
-- The full list of optimizer options can be found in the [Alpine Documentation](https://github.com/lanl-ansi/Alpine.jl)


### PR DESCRIPTION
The unified docs are a nice improvement. I was taking a look:

OptimizationMOI does not provide `:ExprGraph`:
https://github.com/SciML/Optimization.jl/blob/24ad25d3e75816d454349156a7ac6bb094223ad2/lib/OptimizationMOI/src/OptimizationMOI.jl#L30

 so expression-graph based solvers are not supported.

Alpine requests here:
https://github.com/lanl-ansi/Alpine.jl/blob/4bdb11c39ced873cb7cb34afd771a824f25771d7/src/algorithm.jl#L14

AMPLNLWriter requests in the NL file writer:
https://github.com/jump-dev/MathOptInterface.jl/blob/80c9f47947af8e633a54b38839e80685d07f653d/src/FileFormats/NL/NL.jl#L275

BARON requests here:
https://github.com/jump-dev/BARON.jl/blob/0844db158dbb9bf9bcf5d059748f309b9421cd35/src/moi/nlp.jl#L23

cc @ccoffrin 