### PR TITLE
Update docs for OptimizationMOI

### DIFF
--- a/docs/src/optimization_packages/mathoptinterface.md
+++ b/docs/src/optimization_packages/mathoptinterface.md
@@ -1,6 +1,7 @@
 # MathOptInterface.jl
 
-[MathOptInterface](https://github.com/jump-dev/MathOptInterface.jl) is Julia abstration layer to interface with variety of mathematical optimization solvers.
+[MathOptInterface](https://github.com/jump-dev/MathOptInterface.jl) is Julia
+abstration layer to interface with variety of mathematical optimization solvers.
 
 ## Installation: OptimizationMOI.jl
 
@@ -12,13 +13,24 @@ import Pkg; Pkg.add("OptimizationMOI")
 
 ## Details
 
-As of now the `Optimization` interface to `MathOptInterface` implents only the `maxtime` common keyword arguments. An optimizer which is implemented in the `MathOptInterface` is can be called be called directly if no optimizer options have to be defined. For example using the `Ipopt.jl` optimizer:
+As of now, the `Optimization` interface to `MathOptInterface` implements only
+the `maxtime` common keyword argument. 
+
+An optimizer which supports the `MathOptInterface` API can be called be called
+directly if no optimizer options have to be defined. 
+    
+For example using the [`Ipopt.jl`](https://github.com/jump-dev/Ipopt.jl)
+optimizer:
+
 
 ```julia
 sol = solve(prob, Ipopt.Optimizer())
 ```
 
-The optimizer options are handled in one of two ways. They can either be set via `Optimization.MOI.OptimizerWithAttributes()` or as keyword argument to `solve`. For example using the `Ipopt.jl` optimizer:
+The optimizer options are handled in one of two ways. They can either be set via
+`Optimization.MOI.OptimizerWithAttributes()` or as keyword argument to `solve`. 
+
+For example using the `Ipopt.jl` optimizer:
 
 ```julia
 opt = Optimization.MOI.OptimizerWithAttributes(Ipopt.Optimizer, "option_name" => option_value, ...)
@@ -27,32 +39,25 @@ sol = solve(prob, opt)
 sol = solve(prob,  Ipopt.Optimizer(); option_name = option_value, ...)
 ```
 
+## Optimizers
 
-
-## Local Optimizer
-
-### Local constraint
 #### Ipopt.jl (MathOptInterface)
 
-- [`Ipopt.Optimizer`](https://juliahub.com/docs/Ipopt/yMQMo/0.7.0/)
-- Ipopt is a MathOptInterface optimizer, and thus its options are handled via
-  `Optimization.MOI.OptimizerWithAttributes(Ipopt.Optimizer, "option_name" => option_value, ...)`
+- [`Ipopt.Optimizer`](https://github.com/jump-dev/Ipopt.jl)
 - The full list of optimizer options can be found in the [Ipopt Documentation](https://coin-or.github.io/Ipopt/OPTIONS.html#OPTIONS_REF)
 
 #### KNITRO.jl (MathOptInterface)
 
 - [`KNITRO.Optimizer`](https://github.com/jump-dev/KNITRO.jl)
-- KNITRO is a MathOptInterface optimizer, and thus its options are handled via
-  `Optimization.MOI.OptimizerWithAttributes(KNITRO.Optimizer, "option_name" => option_value, ...)`
 - The full list of optimizer options can be found in the [KNITRO Documentation](https://www.artelys.com/docs/knitro//3_referenceManual/callableLibraryAPI.html)
 
 #### Juniper.jl (MathOptInterface)
 
 - [`Juniper.Optimizer`](https://github.com/lanl-ansi/Juniper.jl)
-- Juniper is a MathOptInterface optimizer, and thus its options are handled via
-  `Optimization.MOI.OptimizerWithAttributes(Ipopt.Optimizer, "option_name" => option_value, ...)`
-- Juniper requires the choice of a relaxation method `nl_solver` which must be
-  a MathOptInterface-based optimizer
+- Juniper requires a nonlinear optimizer to be set via the `nl_solver` option,
+  which must be a MathOptInterface-based optimizer. See the
+  [Juniper documentation](https://github.com/lanl-ansi/Juniper.jl) for more
+  detail.
 
 ```julia
 using Optimization, ForwardDiff
@@ -64,18 +69,9 @@ f = OptimizationFunction(rosenbrock, Optimization.AutoForwardDiff())
 prob = Optimization.OptimizationProblem(f, x0, _p)
 
 using Juniper, Ipopt
-optimizer = Juniper.Optimizer
-# Choose a relaxation method
-nl_solver = Optimization.MOI.OptimizerWithAttributes(Ipopt.Optimizer, "print_level"=>0)
-
-opt = Optimization.MOI.OptimizerWithAttributes(optimizer, "nl_solver"=>nl_solver)
+opt = Optimization.MOI.OptimizerWithAttributes(
+    Juniper.Optimizer,
+    "nl_solver"=>Optimization.MOI.OptimizerWithAttributes(Ipopt.Optimizer, "print_level"=>0),
+)
 sol = solve(prob, opt)
 ```
-
-### Gradient-Based
-#### Ipopt.jl (MathOptInterface)
-
-- [`Ipopt.Optimizer`](https://juliahub.com/docs/Ipopt/yMQMo/0.7.0/)
-- Ipopt is a MathOptInterface optimizer, and thus its options are handled via
-  `Optimization.MOI.OptimizerWithAttributes(Ipopt.Optimizer, "option_name" => option_value, ...)`
-- The full list of optimizer options can be found in the [Ipopt Documentation](https://coin-or.github.io/Ipopt/OPTIONS.html#OPTIONS_REF)


### PR DESCRIPTION
This PR makes some minor changes to the OptimizationMOI docs to remove the local
constraint and gradient-based headers (there's no need for Ipopt to appear
twice.)

It is also so we can see if #275 is fixed.