### PR TITLE
Rebase with better tests for ExprGraph

### DIFF
--- a/.github/scripts/baron.sh
+++ b/.github/scripts/baron.sh
@@ -1,6 +1,0 @@
-BARON_EXEC="$HOME/baron-lin64/baron"
-OLDWD=`pwd`
-cd ~
-wget https://minlp.com/downloads/xecs/baron/current/baron-lin64.zip
-unzip baron-lin64.zip
-cd $OLDWD

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,15 +49,10 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - if: ${{ matrix.group == 'OptimizationMOI' }}
-        run: chmod +x ./.github/scripts/baron.sh
-      - if: ${{ matrix.group == 'OptimizationMOI' }}
-        run: ./.github/scripts/baron.sh
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
           GROUP: ${{ matrix.group }}
-          BARON_EXEC: "/home/runner/baron-lin64/baron"
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/lib/OptimizationMOI/.gitignore
+++ b/lib/OptimizationMOI/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/lib/OptimizationMOI/Project.toml
+++ b/lib/OptimizationMOI/Project.toml
@@ -15,14 +15,12 @@ julia = "1"
 
 [extras]
 AmplNLWriter = "7c4d4715-977e-5154-bfe0-e096adeac482"
-BARON = "2e2ca445-9e14-5b13-8677-4410f177f82b"
-Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
-Juniper = "2ddba703-00a4-53a7-87a5-e8b9971dde84"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NLopt = "76087f3c-5699-56af-9a33-bf431cd00edd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Ipopt", "AmplNLWriter", "BARON", "Ipopt_jll", "Juniper", "ModelingToolkit", "NLopt", "Test", "Zygote"]
+test = ["Ipopt", "AmplNLWriter", "Ipopt_jll", "ModelingToolkit", "NLopt", "Test", "Zygote"]

--- a/lib/OptimizationMOI/test/runtests.jl
+++ b/lib/OptimizationMOI/test/runtests.jl
@@ -1,7 +1,8 @@
-using OptimizationMOI, Optimization, Ipopt, NLopt, Zygote, ModelingToolkit, Juniper, BARON
+using OptimizationMOI, Optimization, Ipopt, NLopt, Zygote, ModelingToolkit
+using AmplNLWriter, Ipopt_jll
 using Test
 
-function _test_sparse_derivatives_hs071(backend)
+function _test_sparse_derivatives_hs071(backend, optimizer)
     function objective(x, ::Any)
         return x[1] * x[4] * (x[1] + x[2] + x[3]) + x[3]
     end
@@ -20,7 +21,7 @@ function _test_sparse_derivatives_hs071(backend)
         lcons = [25.0, 40.0],
         ucons = [Inf, 40.0],
     )
-    sol = solve(prob, Ipopt.Optimizer())
+    sol = solve(prob, optimizer)
     @test isapprox(sol.minimum, 17.014017145179164; atol = 1e-6)
     x = [1.0, 4.7429996418092970, 3.8211499817883077, 1.3794082897556983]
     @test isapprox(sol.minimizer, x; atol = 1e-6)
@@ -68,18 +69,6 @@ end
 
     sol = solve(prob, OptimizationMOI.MOI.OptimizerWithAttributes(Ipopt.Optimizer, "max_cpu_time" => 60.0))
     @test 10 * sol.minimum < l1
-
-    nl_solver = OptimizationMOI.MOI.OptimizerWithAttributes(Ipopt.Optimizer, "print_level" => 0)
-    minlp_solver = OptimizationMOI.MOI.OptimizerWithAttributes(Juniper.Optimizer, "nl_solver" => nl_solver)
-
-    sol = solve(prob, minlp_solver)
-    @test 10 * sol.minimum < l1
-
-    cons = (x, p) -> [x[2] - x[1]]
-    optprob = OptimizationFunction(rosenbrock, Optimization.AutoModelingToolkit(true, true); cons=cons)
-    prob = OptimizationProblem(optprob, x0, _p, ucons=[0.0], lcons=[0.0])
-    sol = solve(prob, BARON.Optimizer())
-    @test 10 * sol.minimum < l1
 end
 
 @testset "backends" begin
@@ -90,7 +79,8 @@ end
         Optimization.AutoModelingToolkit(true, true),
     )
         @testset "$backend" begin
-            _test_sparse_derivatives_hs071(backend)
+            _test_sparse_derivatives_hs071(backend, Ipopt.Optimizer())
+            _test_sparse_derivatives_hs071(backend, AmplNLWriter.Optimizer(Ipopt_jll.amplexe))
         end
     end
 end


### PR DESCRIPTION
I removed Juniper and BARON in favor of AmplNLWriter. They don't add anything since you aren't solving MINLPs. They're also unsupported by the `jump-dev` org, so they might go stale in the long-run, and BARON requires a commercial license.

I still need to debug a problem:
```Julia
using Optimization
using Test

import AmplNLWriter
import Ipopt_jll
import ModelingToolkit
import OptimizationMOI

function objective(x, ::Any)
    return x[1] * x[4] * (x[1] + x[2] + x[3]) + x[3]
end

function constraints(x, ::Any)
    return [
        x[1] * x[2] * x[3] * x[4],
        x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2,
    ]
end

prob = OptimizationProblem(
    OptimizationFunction(objective, Optimization.AutoModelingToolkit(true, true); cons = constraints),
    [1.0, 5.0, 5.0, 1.0];
    sense = Optimization.MinSense,
    lb = [1.0, 1.0, 1.0, 1.0],
    ub = [5.0, 5.0, 5.0, 5.0],
    lcons = [25.0, 40.0],
    ucons = [Inf, 40.0],
)

sol = solve(prob, AmplNLWriter.Optimizer(Ipopt_jll.amplexe))
```
yields
```
Ipopt 3.14.4: 
bad line 64 of /var/folders/bg/dzq_hhvx1dxgy6gb5510pxj80000gn/T/jl_QMKxlt/model.nl: J0 0
Cannot open .nl file
libc++abi: terminating with uncaught exception of type Ipopt::TNLP::INVALID_TNLP
u: 4-element Vector{Float64}:
 NaN
 NaN
 NaN
 NaN
```