### PR TITLE
typo in rosenbrock function in docs

### DIFF
--- a/docs/src/tutorials/intro.md
+++ b/docs/src/tutorials/intro.md
@@ -8,7 +8,7 @@ code to get started is the following:
 ```@example intro
 # Import the package and define the problem to optimize
 using Optimization
-rosenbrock(u,p) =  (u[1] - u[1])^2 + p[2] * (u[2] - u[1]^2)^2
+rosenbrock(u,p) =  (p[1] - u[1])^2 + p[2] * (u[2] - u[1]^2)^2
 u0 = zeros(2)
 p  = [1.0,100.0]
 


### PR DESCRIPTION
There is a typo in the basic usage documentation.

Where the rosenbrock function is defined, the first square should be `(p[1] - u[1])^2`, but `(u[1] - u[1])^2` was written instead.