### PR TITLE
Use `empty!` instead of `instantiate` to support reuse of MOI optimizers

### DIFF
--- a/lib/OptimizationMOI/src/OptimizationMOI.jl
+++ b/lib/OptimizationMOI/src/OptimizationMOI.jl
@@ -17,7 +17,7 @@ function SciMLBase.allowsconstraints(opt::Union{MOI.AbstractOptimizer,
     true
 end
 function SciMLBase.allowscallback(opt::Union{MOI.AbstractOptimizer,
-                                                MOI.OptimizerWithAttributes})
+                                             MOI.OptimizerWithAttributes})
     false
 end
 
@@ -241,13 +241,16 @@ function _create_new_optimizer(opt::MOI.OptimizerWithAttributes)
 end
 
 function _create_new_optimizer(model::MOI.AbstractOptimizer)
+    if !MOI.is_empty(model)
+        MOI.empty!(model)
+    end
     if MOI.supports_incremental_interface(model)
-        return MOI.instantiate(typeof(model))
+        return model
     end
     return MOI.Utilities.CachingOptimizer(MOI.Utilities.UniversalFallback(MOI.Utilities.Model{
                                                                                               Float64
                                                                                               }()),
-                                          MOI.instantiate(typeof(model)))
+                                          model)
 end
 
 function __map_optimizer_args(prob::OptimizationProblem,
@@ -284,7 +287,6 @@ function SciMLBase.__solve(prob::OptimizationProblem,
                            abstol::Union{Number, Nothing} = nothing,
                            reltol::Union{Number, Nothing} = nothing,
                            kwargs...)
-
     maxiters = Optimization._check_and_convert_maxiters(maxiters)
     maxtime = Optimization._check_and_convert_maxtime(maxtime)
     opt_setup = __map_optimizer_args(prob,

--- a/lib/OptimizationMOI/test/runtests.jl
+++ b/lib/OptimizationMOI/test/runtests.jl
@@ -43,7 +43,10 @@ end
     optprob = OptimizationFunction(rosenbrock, Optimization.AutoZygote())
     prob = OptimizationProblem(optprob, x0, _p; sense = Optimization.MinSense)
 
-    sol = solve(prob, Ipopt.Optimizer())
+    opt = Ipopt.Optimizer()
+    sol = solve(prob, opt)
+    @test 10 * sol.minimum < l1
+    sol = solve(prob, opt) #test reuse of optimizer
     @test 10 * sol.minimum < l1
 
     sol = solve(prob,
@@ -61,9 +64,11 @@ end
                                                             "algorithm" => :LD_LBFGS))
     @test 10 * sol.minimum < l1
 
-    sol = solve(prob,
-                OptimizationMOI.MOI.OptimizerWithAttributes(NLopt.Optimizer,
-                                                            "algorithm" => :LD_LBFGS))
+    opt = OptimizationMOI.MOI.OptimizerWithAttributes(NLopt.Optimizer,
+                                                      "algorithm" => :LD_LBFGS)
+    sol = solve(prob, opt)
+    @test 10 * sol.minimum < l1
+    sol = solve(prob, opt)
     @test 10 * sol.minimum < l1
 
     cons_circ = (res, x, p) -> res .= [x[1]^2 + x[2]^2]


### PR DESCRIPTION
Fixes #347 