### PR TITLE
Change NLopt to OptimizationNLopt

### DIFF
--- a/docs/src/optimization_packages/nlopt.md
+++ b/docs/src/optimization_packages/nlopt.md
@@ -93,7 +93,7 @@ The Rosenbrock function can be optimized using the `NLopt.LN_NELDERMEAD()` as fo
 
 ```@example NLopt1
 using Optimization
-using NLopt
+using OptimizationNLopt
 rosenbrock(x, p) =  (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
 x0 = zeros(2)
 p  = [1.0, 100.0]


### PR DESCRIPTION
With `using NLopt`, you get

```julia
using Optimization
using NLopt
rosenbrock(x, p) =  (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
x0 = zeros(2)
p  = [1.0, 100.0]
f = OptimizationFunction(rosenbrock)
prob = Optimization.OptimizationProblem(f, x0, p, lb = [-1.0,-1.0], ub = [1.0,1.0])
sol = solve(prob, NLopt.LN_NELDERMEAD())
ERROR: MethodError: objects of type Algorithm are not callable
Stacktrace:
 [1] top-level scope
   @ Untitled-1:8
```
this is fixed when doing `using OptimizationNLopt` (and matches the rest of the tutorial).