### PR TITLE
Add box constraints column to table

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,21 +41,21 @@ packages.
 
 ## Overview of the Optimizers
 
-| Package                 | Local Gradient-Based | Local Hessian-Based | Local Derivative-Free | Local Constrained | Global Unconstrained | Global Constrained |
-|:----------------------- |:--------------------:|:-------------------:|:---------------------:|:-----------------:|:--------------------:|:------------------:|
-| BlackBoxOptim           | ❌                    | ❌                   | ❌                     | ❌                 | ✅                    | ❌                  |
-| CMAEvolutionaryStrategy | ❌                    | ❌                   | ❌                     | ❌                 | ✅                    | ❌                  |
-| Evolutionary            | ❌                    | ❌                   | ❌                     | ❌                 | ✅                    | 🟡                  |
-| Flux                    | ✅                    | ❌                   | ❌                     | ❌                 | ❌                    | ❌                  |
-| GCMAES                  | ❌                    | ❌                   | ❌                     | ❌                 | ✅                    | ❌                  |
-| MathOptInterface        | ✅                    | ✅                   | ✅                     | ✅                 | ✅                    | 🟡                  |
-| MultistartOptimization  | ❌                    | ❌                   | ❌                     | ❌                 | ✅                    | ❌                  |
-| Metaheuristics          | ❌                    | ❌                   | ❌                     | ❌                 | ✅                    | 🟡                  |
-| NOMAD                   | ❌                    | ❌                   | ❌                     | ❌                 | ✅                    | 🟡                  |
-| NLopt                   | ✅                    | ❌                   | ✅                     | 🟡                 | ✅                    | 🟡                  |
-| Nonconvex               | ✅                    | ✅                   | ✅                     | 🟡                 | ✅                    | 🟡                  |
-| Optim                   | ✅                    | ✅                   | ✅                     | ✅                 | ✅                    | ✅                  |
-| QuadDIRECT              | ❌                    | ❌                   | ❌                     | ❌                 | ✅                    | ❌                  |
+| Package                 | Local Gradient-Based | Local Hessian-Based | Local Derivative-Free | Box Constraints | Local Constrained | Global Unconstrained | Global Constrained |
+|:----------------------- |:--------------------:|:-------------------:|:---------------------:|:---------------:|:-----------------:|:--------------------:|:------------------:|
+| BlackBoxOptim           | ❌                    | ❌                   | ❌                   |✅              | ❌                 | ✅                    | ❌                  |✅              
+| CMAEvolutionaryStrategy | ❌                    | ❌                   | ❌                   |✅                | ❌                 | ✅                    | ❌                  |
+| Evolutionary            | ❌                    | ❌                   | ❌                   |✅                | ❌                 | ✅                    | 🟡                  |
+| Flux                    | ✅                    | ❌                   | ❌                   |❌                | ❌                 | ❌                    | ❌                  |
+| GCMAES                  | ❌                    | ❌                   | ❌                   |✅                | ❌                 | ✅                    | ❌                  |
+| MathOptInterface        | ✅                    | ✅                   | ✅                   |✅                | ✅                 | ✅                    | 🟡                  |
+| MultistartOptimization  | ❌                    | ❌                   | ❌                   |✅                | ❌                 | ✅                    | ❌                  |
+| Metaheuristics          | ❌                    | ❌                   | ❌                   |✅                | ❌                 | ✅                    | 🟡                  |
+| NOMAD                   | ❌                    | ❌                   | ❌                   |✅                | ❌                 | ✅                    | 🟡                  |
+| NLopt                   | ✅                    | ❌                   | ✅                   |✅                | 🟡                 | ✅                    | 🟡                  |
+| Nonconvex               | ✅                    | ✅                   | ✅                   |✅                | 🟡                 | ✅                    | 🟡                  |
+| Optim                   | ✅                    | ✅                   | ✅                   |✅                | ✅                 | ✅                    | ✅                  |
+| QuadDIRECT              | ❌                    | ❌                   | ❌                   |✅                | ❌                 | ✅                    | ❌                  |
 
 ✅ = supported
 


### PR DESCRIPTION
This will make it clear that the constraints column is separate to whether an optimiser permits box constraints. I couldn't see anything about Flux allowing box constraints - does it? I've never used it and saw no tests involving it. Optimisers is also not in this table, I guess because it's going to replace Flux.