### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/src/tutorials/constraints.md
+++ b/docs/src/tutorials/constraints.md
@@ -11,7 +11,7 @@ Let's define the rosenbrock function as our objective function and consider the 
 
 x_1^2 + x_2^2 \leq 0.8 \\
 
-0.0 \leq x_1 * x_2 \leq 5.0
+-1.0 \leq x_1 * x_2 \leq 2.0
 \end{aligned}
 ```
 


### PR DESCRIPTION
In the documentation of constraints, I believe the definition of the second inequality uses bounds that are inconsistent with the actual call:
```julia
prob = OptimizationProblem(optprob, x0, _p, lcons = [-Inf, -1.0], ucons = [0.8, 2.0])
```
a few lines below