### PR TITLE
generate `lag_h` function for FiniteDiff

### DIFF
--- a/src/function/finitediff.jl
+++ b/src/function/finitediff.jl
@@ -1,3 +1,4 @@
+const FD = FiniteDiff
 """
 AutoFiniteDiff{T1,T2,T3} <: AbstractADType
 
@@ -54,23 +55,18 @@ function instantiate_function(f, x, adtype::AutoFiniteDiff, p,
     updatecache = (cache, x) -> (cache.xmm .= x; cache.xmp .= x; cache.xpm .= x; cache.xpp .= x; return cache)
 
     if f.grad === nothing
-        gradcache = FiniteDiff.GradientCache(x, x, adtype.fdtype)
-        grad = (res, θ, args...) -> FiniteDiff.finite_difference_gradient!(res,
-                                                                           x -> _f(x,
-                                                                                   args...),
-                                                                           θ, gradcache)
+        gradcache = FD.GradientCache(x, x, adtype.fdtype)
+        grad = (res, θ, args...) -> FD.finite_difference_gradient!(res, x -> _f(x, args...),
+                                                                   θ, gradcache)
     else
         grad = (G, θ, args...) -> f.grad(G, θ, p, args...)
     end
 
     if f.hess === nothing
-        hesscache = FiniteDiff.HessianCache(x, adtype.fdhtype)
-        hess = (res, θ, args...) -> FiniteDiff.finite_difference_hessian!(res,
-                                                                          x -> _f(x,
-                                                                                  args...),
-                                                                          θ,
-                                                                          updatecache(hesscache,
-                                                                                      θ))
+        hesscache = FD.HessianCache(x, adtype.fdhtype)
+        hess = (res, θ, args...) -> FD.finite_difference_hessian!(res,
+                                                                  x -> _f(x, args...), θ,
+                                                                  updatecache(hesscache, θ))
     else
         hess = (H, θ, args...) -> f.hess(H, θ, p, args...)
     end
@@ -97,39 +93,61 @@ function instantiate_function(f, x, adtype::AutoFiniteDiff, p,
     if cons !== nothing && f.cons_j === nothing
         cons_j = function (J, θ)
             y0 = zeros(num_cons)
-            jaccache = FiniteDiff.JacobianCache(copy(x), copy(y0), copy(y0), adtype.fdjtype;
-                                                colorvec = cons_jac_colorvec,
-                                                sparsity = f.cons_jac_prototype)
-            FiniteDiff.finite_difference_jacobian!(J, cons, θ, jaccache)
+            jaccache = FD.JacobianCache(copy(x), copy(y0), copy(y0), adtype.fdjtype;
+                                        colorvec = cons_jac_colorvec,
+                                        sparsity = f.cons_jac_prototype)
+            FD.finite_difference_jacobian!(J, cons, θ, jaccache)
         end
     else
         cons_j = (J, θ) -> f.cons_j(J, θ, p)
     end
 
     if cons !== nothing && f.cons_h === nothing
-        hess_cons_cache = [FiniteDiff.HessianCache(copy(x), adtype.fdhtype)
+        hess_cons_cache = [FD.HessianCache(copy(x), adtype.fdhtype)
                            for i in 1:num_cons]
         cons_h = function (res, θ)
             for i in 1:num_cons#note: colorvecs not yet supported by FiniteDiff for Hessians
-                FiniteDiff.finite_difference_hessian!(res[i],
-                                                      (x) -> (_res = zeros(eltype(θ),
-                                                                           num_cons);
-                                                              cons(_res,
-                                                                   x);
-                                                              _res[i]),
-                                                      θ, updatecache(hess_cons_cache[i], θ))
+                FD.finite_difference_hessian!(res[i],
+                                              (x) -> (_res = zeros(eltype(θ), num_cons);
+                                                      cons(_res, x);
+                                                      _res[i]), θ,
+                                              updatecache(hess_cons_cache[i], θ))
             end
         end
     else
         cons_h = (res, θ) -> f.cons_h(res, θ, p)
     end
 
+    if f.lag_h === nothing
+        lag_hess_cache = FD.HessianCache(copy(x), adtype.fdhtype)
+        c = zeros(num_cons)
+        h = zeros(length(x), length(x))
+        lag_h = let c = c, h = h
+            lag = function (θ, σ, μ)
+                f.cons(c, θ, p)
+                l = μ'c
+                if !iszero(σ)
+                    l += σ * f.f(θ, p)
+                end
+                l
+            end
+            function (res, θ, σ, μ)
+                FD.finite_difference_hessian!(res,
+                                              (x) -> lag(x, σ, μ),
+                                              θ,
+                                              updatecache(lag_hess_cache, θ))
+            end
+        end
+    else
+        lag_h = (res, θ, σ, μ) -> f.lag_h(res, θ, σ, μ, p)
+    end
     return OptimizationFunction{true}(f, adtype; grad = grad, hess = hess, hv = hv,
                                       cons = cons, cons_j = cons_j, cons_h = cons_h,
                                       cons_jac_colorvec = cons_jac_colorvec,
                                       hess_prototype = f.hess_prototype,
                                       cons_jac_prototype = f.cons_jac_prototype,
-                                      cons_hess_prototype = f.cons_hess_prototype)
+                                      cons_hess_prototype = f.cons_hess_prototype,
+                                      lag_h, f.lag_hess_prototype)
 end
 
 function instantiate_function(f, cache::ReInitCache,
@@ -138,23 +156,18 @@ function instantiate_function(f, cache::ReInitCache,
     updatecache = (cache, x) -> (cache.xmm .= x; cache.xmp .= x; cache.xpm .= x; cache.xpp .= x; return cache)
 
     if f.grad === nothing
-        gradcache = FiniteDiff.GradientCache(cache.u0, cache.u0, adtype.fdtype)
-        grad = (res, θ, args...) -> FiniteDiff.finite_difference_gradient!(res,
-                                                                           x -> _f(x,
-                                                                                   args...),
-                                                                           θ, gradcache)
+        gradcache = FD.GradientCache(cache.u0, cache.u0, adtype.fdtype)
+        grad = (res, θ, args...) -> FD.finite_difference_gradient!(res, x -> _f(x, args...),
+                                                                   θ, gradcache)
     else
         grad = (G, θ, args...) -> f.grad(G, θ, cache.p, args...)
     end
 
     if f.hess === nothing
-        hesscache = FiniteDiff.HessianCache(cache.u0, adtype.fdhtype)
-        hess = (res, θ, args...) -> FiniteDiff.finite_difference_hessian!(res,
-                                                                          x -> _f(x,
-                                                                                  args...),
-                                                                          θ,
-                                                                          updatecache(hesscache,
-                                                                                      θ))
+        hesscache = FD.HessianCache(cache.u0, adtype.fdhtype)
+        hess = (res, θ, args...) -> FD.finite_difference_hessian!(res, x -> _f(x, args...),
+                                                                  θ,
+                                                                  updatecache(hesscache, θ))
     else
         hess = (H, θ, args...) -> f.hess(H, θ, cache.p, args...)
     end
@@ -181,38 +194,65 @@ function instantiate_function(f, cache::ReInitCache,
     if cons !== nothing && f.cons_j === nothing
         cons_j = function (J, θ)
             y0 = zeros(num_cons)
-            jaccache = FiniteDiff.JacobianCache(copy(cache.u0), copy(y0), copy(y0),
-                                                adtype.fdjtype;
-                                                colorvec = cons_jac_colorvec,
-                                                sparsity = f.cons_jac_prototype)
-            FiniteDiff.finite_difference_jacobian!(J, cons, θ, jaccache)
+            jaccache = FD.JacobianCache(copy(cache.u0), copy(y0), copy(y0),
+                                        adtype.fdjtype;
+                                        colorvec = cons_jac_colorvec,
+                                        sparsity = f.cons_jac_prototype)
+            FD.finite_difference_jacobian!(J, cons, θ, jaccache)
         end
     else
         cons_j = (J, θ) -> f.cons_j(J, θ, cache.p)
     end
 
     if cons !== nothing && f.cons_h === nothing
-        hess_cons_cache = [FiniteDiff.HessianCache(copy(cache.u0), adtype.fdhtype)
+        hess_cons_cache = [FD.HessianCache(copy(cache.u0), adtype.fdhtype)
                            for i in 1:num_cons]
         cons_h = function (res, θ)
             for i in 1:num_cons#note: colorvecs not yet supported by FiniteDiff for Hessians
-                FiniteDiff.finite_difference_hessian!(res[i],
-                                                      (x) -> (_res = zeros(eltype(θ),
-                                                                           num_cons);
-                                                              cons(_res,
-                                                                   x);
-                                                              _res[i]),
-                                                      θ, updatecache(hess_cons_cache[i], θ))
+                FD.finite_difference_hessian!(res[i],
+                                              (x) -> (_res = zeros(eltype(θ), num_cons);
+                                                      cons(_res,
+                                                           x);
+                                                      _res[i]),
+                                              θ, updatecache(hess_cons_cache[i], θ))
             end
         end
     else
         cons_h = (res, θ) -> f.cons_h(res, θ, cache.p)
     end
-
+    if f.lag_h === nothing
+        lag_hess_cache = FD.HessianCache(copy(cache.u0), adtype.fdhtype)
+        c = zeros(num_cons)
+        h = zeros(length(cache.u0), length(cache.u0))
+        lag_h = let c = c, h = h
+            lag = function (θ, σ, μ)
+                f.cons(c, θ, cache.p)
+                l = μ'c
+                if !iszero(σ)
+                    l += σ * f.f(θ, cache.p)
+                end
+                l
+            end
+            function (res, θ, σ, μ)
+                FD.finite_difference_hessian!(h,
+                                              (x) -> lag(x, σ, μ),
+                                              θ,
+                                              updatecache(lag_hess_cache, θ))
+                k = 1
+                for i in 1:length(cache.u0), j in i:length(cache.u0)
+                    res[k] = h[i, j]
+                    k += 1
+                end
+            end
+        end
+    else
+        lag_h = (res, θ, σ, μ) -> f.lag_h(res, θ, σ, μ, cache.p)
+    end
     return OptimizationFunction{true}(f, adtype; grad = grad, hess = hess, hv = hv,
                                       cons = cons, cons_j = cons_j, cons_h = cons_h,
                                       cons_jac_colorvec = cons_jac_colorvec,
                                       hess_prototype = f.hess_prototype,
                                       cons_jac_prototype = f.cons_jac_prototype,
-                                      cons_hess_prototype = f.cons_hess_prototype)
+                                      cons_hess_prototype = f.cons_hess_prototype,
+                                      lag_h, f.lag_hess_prototype)
 end

--- a/test/ADtests.jl
+++ b/test/ADtests.jl
@@ -234,6 +234,12 @@ H3 = [Array{Float64}(undef, 2, 2)]
 optprob.cons_h(H3, x0)
 @test H3 ≈ [[2.0 0.0; 0.0 2.0]]
 
+H4 = Array{Float64}(undef, 2, 2)
+μ = randn(1)
+σ = rand()
+optprob.lag_h(H4, x0, σ, μ)
+@test H4≈σ * H1 + μ[1] * H3[1] rtol=1e-6
+
 cons_jac_proto = Float64.(sparse([1 1])) # Things break if you only use [1 1]; see FiniteDiff.jl
 cons_jac_colors = 1:2
 optf = OptimizationFunction(rosenbrock, Optimization.AutoFiniteDiff(), cons = cons,


### PR DESCRIPTION
Also introduce shorthand
```julia
const FD = FiniteDiff
```
to improve the otherwise poor auto formatting