### PR TITLE
Remove buggy `structural_simplify` usage

### DIFF
--- a/ext/OptimizationMTKExt.jl
+++ b/ext/OptimizationMTKExt.jl
@@ -15,7 +15,7 @@ function Optimization.instantiate_function(f, x, adtype::AutoModelingToolkit, p,
                                                                               num_cons),
                                                                  ucons = fill(0.0,
                                                                               num_cons)))
-    sys = ModelingToolkit.structural_simplify(sys)
+    #sys = ModelingToolkit.structural_simplify(sys)
     f = OptimizationProblem(sys, x, p, grad = true, hess = true,
                             sparse = adtype.obj_sparse, cons_j = true, cons_h = true,
                             cons_sparse = adtype.cons_sparse).f
@@ -55,7 +55,7 @@ function Optimization.instantiate_function(f, cache::Optimization.ReInitCache,
                                                                               num_cons),
                                                                  ucons = fill(0.0,
                                                                               num_cons)))
-    sys = ModelingToolkit.structural_simplify(sys)
+    #sys = ModelingToolkit.structural_simplify(sys)
     f = OptimizationProblem(sys, cache.u0, cache.p, grad = true, hess = true,
                             sparse = adtype.obj_sparse, cons_j = true, cons_h = true,
                             cons_sparse = adtype.cons_sparse).f


### PR DESCRIPTION
The use of `structural_simplify` seems untested. Note `structural_simplify` could alter the number of constraints. So code like
https://github.com/SciML/Optimization.jl/blob/91665075ef767cb35661766889e494e68de07bf3/lib/OptimizationMOI/src/nlp.jl#L87-L90
in the presence of `structural_simplify` is incorrect.