### PR TITLE
Do not ignore the initial guess in OptimizationBBO

### DIFF
--- a/lib/OptimizationBBO/Project.toml
+++ b/lib/OptimizationBBO/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationBBO"
 uuid = "3e6eede4-6085-4f62-9a71-46d9bc1eb92b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"

--- a/lib/OptimizationBBO/src/OptimizationBBO.jl
+++ b/lib/OptimizationBBO/src/OptimizationBBO.jl
@@ -139,7 +139,11 @@ function SciMLBase.__solve(prob::SciMLBase.OptimizationProblem, opt::BBO,
 
     t0 = time()
 
-    opt_res = BlackBoxOptim.bboptimize(opt_setup)
+    if isnothing(prob.u0)
+        opt_res = BlackBoxOptim.bboptimize(opt_setup)
+    else
+        opt_res = BlackBoxOptim.bboptimize(opt_setup, prob.u0)
+    end
 
     if progress
         # Set progressbar to 1 to finish it

--- a/lib/OptimizationBBO/test/runtests.jl
+++ b/lib/OptimizationBBO/test/runtests.jl
@@ -13,6 +13,11 @@ using Test
     sol = solve(prob, BBO_adaptive_de_rand_1_bin_radiuslimited())
     @test 10 * sol.objective < l1
 
+    prob = Optimization.OptimizationProblem(optprob, nothing, _p, lb = [-1.0, -1.0],
+                                            ub = [0.8, 0.8])
+    sol = solve(prob, BBO_adaptive_de_rand_1_bin_radiuslimited())
+    @test 10 * sol.objective < l1
+
     sol = solve(prob, BBO_adaptive_de_rand_1_bin_radiuslimited(),
                 callback = (args...) -> false)
     @test 10 * sol.objective < l1


### PR DESCRIPTION
Currently OptimizationBBO ignores the initial condition, this PR passes it on if `prob.u0` is not `nothing`, so that if one does not have a initial guess they can pass nothing, otherwise the initial guess that is passed is forwarded to `BlackBoxOptim.bboptimize`, as mentioned here: https://github.com/robertfeldt/BlackBoxOptim.jl#providing-initial-solutions

I'm not sure how I can check that this initial guess is correctly used by BBO, so I just tested that the new and old behvior work.