### PR TITLE
remove second copy of __moi_status_to_ReturnCode

### DIFF
--- a/lib/OptimizationMOI/src/OptimizationMOI.jl
+++ b/lib/OptimizationMOI/src/OptimizationMOI.jl
@@ -161,50 +161,6 @@ function repl_getindex!(expr::Expr)
     return expr
 end
 
-function __moi_status_to_ReturnCode(status::MOI.TerminationStatusCode)
-    if status in [
-        MOI.OPTIMAL,
-        MOI.LOCALLY_SOLVED,
-        MOI.ALMOST_OPTIMAL,
-        MOI.ALMOST_LOCALLY_SOLVED,
-    ]
-        return ReturnCode.Success
-    elseif status in [
-        MOI.INFEASIBLE,
-        MOI.DUAL_INFEASIBLE,
-        MOI.LOCALLY_INFEASIBLE,
-        MOI.INFEASIBLE_OR_UNBOUNDED,
-        MOI.ALMOST_INFEASIBLE,
-        MOI.ALMOST_DUAL_INFEASIBLE,
-    ]
-        return ReturnCode.Infeasible
-    elseif status in [
-        MOI.ITERATION_LIMIT,
-        MOI.NODE_LIMIT,
-        MOI.SLOW_PROGRESS,
-    ]
-        return ReturnCode.MaxIters
-    elseif status == MOI.TIME_LIMIT
-        return ReturnCode.MaxTime
-    elseif status in [
-        MOI.OPTIMIZE_NOT_CALLED,
-        MOI.NUMERICAL_ERROR,
-        MOI.INVALID_MODEL,
-        MOI.INVALID_OPTION,
-        MOI.INTERRUPTED,
-        MOI.OTHER_ERROR,
-        MOI.SOLUTION_LIMIT,
-        MOI.MEMORY_LIMIT,
-        MOI.OBJECTIVE_LIMIT,
-        MOI.NORM_LIMIT,
-        MOI.OTHER_LIMIT,
-    ]
-        return ReturnCode.Failure
-    else
-        return ReturnCode.Default
-    end
-end
-
 include("nlp.jl")
 include("moi.jl")
 


### PR DESCRIPTION
These two functions are indentical:
https://github.com/SciML/Optimization.jl/blob/f911aba86b981d03941223bc284c04fff3b05ec0/lib/OptimizationMOI/src/OptimizationMOI.jl#L75
https://github.com/SciML/Optimization.jl/blob/f911aba86b981d03941223bc284c04fff3b05ec0/lib/OptimizationMOI/src/OptimizationMOI.jl#L164

Fixes precompilation of OptimizationMOI:

```
  1 dependency had warnings during precompilation:
┌ OptimizationMOI [fd9f6733-72f4-499f-8506-86b2bdd0dea1]
│  WARNING: Method definition __moi_status_to_ReturnCode(MathOptInterface.TerminationStatusCode) in module OptimizationMOI at .julia\packages\OptimizationMOI\QjPKM\src\OptimizationMOI.jl:75 overwritten at .julia\packages\OptimizationMOI\QjPKM\src\OptimizationMOI.jl:164.
│    ** incremental compilation may be fatally broken for this module **
└
```
