### PR TITLE
Improve Performance for OptimizationBBO

### DIFF
--- a/lib/OptimizationBBO/src/OptimizationBBO.jl
+++ b/lib/OptimizationBBO/src/OptimizationBBO.jl
@@ -112,7 +112,7 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
     cur, state = iterate(cache.data)
 
     function _cb(trace)
-        if isnothing(cache.callback)
+        if cache.callback == DEFAULT_CALLBACK
             cb_call = false
         else
             cb_call = cache.callback(decompose_trace(trace, cache.progress), x...)
@@ -135,9 +135,9 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
     maxtime = Optimization._check_and_convert_maxtime(cache.solver_args.maxtime)
 
     _loss = function (θ)
-        if isnothing(cache.callback) && cache.data == Optimization.DEFAULT_DATA
+        if cache.callback == DEFAULT_CALLBACK && cache.data == Optimization.DEFAULT_DATA
             return first(cache.f(θ, cache.p))
-        elseif isnothing(cache.callback)
+        elseif cache.callback == DEFAULT_CALLBACK
             return first(cache.f(θ, cache.p, cur...))
         elseif cache.data != Optimization.DEFAULT_DATA
             x = cache.f(θ, cache.p)
@@ -149,7 +149,7 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
     end
 
     opt_args = __map_optimizer_args(cache, cache.opt;
-        callback = isnothing(cache.callback) &&
+        callback = cache.callback == DEFAULT_CALLBACK &&
                    cache.data == Optimization.DEFAULT_DATA ?
                    nothing : _cb,
         cache.solver_args...,

--- a/lib/OptimizationBBO/src/OptimizationBBO.jl
+++ b/lib/OptimizationBBO/src/OptimizationBBO.jl
@@ -125,7 +125,7 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
             BlackBoxOptim.shutdown_optimizer!(trace) #doesn't work
         end
 
-        if !isnothing(cache.data)
+        if cache.data != Optimization.DEFAULT_DATA
             cur, state = iterate(cache.data, state)
         end
         cb_call
@@ -135,11 +135,11 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
     maxtime = Optimization._check_and_convert_maxtime(cache.solver_args.maxtime)
 
     _loss = function (θ)
-        if isnothing(cache.callback) && isnothing(cache.data)
+        if isnothing(cache.callback) && cache.data == Optimization.DEFAULT_DATA
             return first(cache.f(θ, cache.p))
         elseif isnothing(cache.callback)
             return first(cache.f(θ, cache.p, cur...))
-        elseif isnothing(cache.data)
+        elseif cache.data != Optimization.DEFAULT_DATA
             x = cache.f(θ, cache.p)
             return first(x)
         else
@@ -150,7 +150,7 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
 
     opt_args = __map_optimizer_args(cache, cache.opt;
         callback = isnothing(cache.callback) &&
-                   isnothing(cache.data) ?
+                   cache.data == Optimization.DEFAULT_DATA ?
                    nothing : _cb,
         cache.solver_args...,
         maxiters = maxiters,

--- a/lib/OptimizationBBO/src/OptimizationBBO.jl
+++ b/lib/OptimizationBBO/src/OptimizationBBO.jl
@@ -112,7 +112,7 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
     cur, state = iterate(cache.data)
 
     function _cb(trace)
-        if cache.callback == Optimization.DEFAULT_CALLBACK
+        if cache.callback === Optimization.DEFAULT_CALLBACK
             cb_call = false
         else
             cb_call = cache.callback(decompose_trace(trace, cache.progress), x...)
@@ -125,7 +125,7 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
             BlackBoxOptim.shutdown_optimizer!(trace) #doesn't work
         end
 
-        if cache.data != Optimization.DEFAULT_DATA
+        if cache.data !== Optimization.DEFAULT_DATA
             cur, state = iterate(cache.data, state)
         end
         cb_call
@@ -135,11 +135,11 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
     maxtime = Optimization._check_and_convert_maxtime(cache.solver_args.maxtime)
 
     _loss = function (θ)
-        if cache.callback == Optimization.DEFAULT_CALLBACK && cache.data == Optimization.DEFAULT_DATA
+        if cache.callback === Optimization.DEFAULT_CALLBACK && cache.data === Optimization.DEFAULT_DATA
             return first(cache.f(θ, cache.p))
-        elseif cache.callback == Optimization.DEFAULT_CALLBACK
+        elseif cache.callback === Optimization.DEFAULT_CALLBACK
             return first(cache.f(θ, cache.p, cur...))
-        elseif cache.data != Optimization.DEFAULT_DATA
+        elseif cache.data !== Optimization.DEFAULT_DATA
             x = cache.f(θ, cache.p)
             return first(x)
         else
@@ -149,8 +149,8 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
     end
 
     opt_args = __map_optimizer_args(cache, cache.opt;
-        callback = cache.callback == Optimization.DEFAULT_CALLBACK &&
-                   cache.data == Optimization.DEFAULT_DATA ?
+        callback = cache.callback === Optimization.DEFAULT_CALLBACK &&
+                   cache.data === Optimization.DEFAULT_DATA ?
                    nothing : _cb,
         cache.solver_args...,
         maxiters = maxiters,

--- a/lib/OptimizationBBO/src/OptimizationBBO.jl
+++ b/lib/OptimizationBBO/src/OptimizationBBO.jl
@@ -112,7 +112,7 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
     cur, state = iterate(cache.data)
 
     function _cb(trace)
-        if cache.callback == DEFAULT_CALLBACK
+        if cache.callback == Optimization.DEFAULT_CALLBACK
             cb_call = false
         else
             cb_call = cache.callback(decompose_trace(trace, cache.progress), x...)
@@ -135,9 +135,9 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
     maxtime = Optimization._check_and_convert_maxtime(cache.solver_args.maxtime)
 
     _loss = function (θ)
-        if cache.callback == DEFAULT_CALLBACK && cache.data == Optimization.DEFAULT_DATA
+        if cache.callback == Optimization.DEFAULT_CALLBACK && cache.data == Optimization.DEFAULT_DATA
             return first(cache.f(θ, cache.p))
-        elseif cache.callback == DEFAULT_CALLBACK
+        elseif cache.callback == Optimization.DEFAULT_CALLBACK
             return first(cache.f(θ, cache.p, cur...))
         elseif cache.data != Optimization.DEFAULT_DATA
             x = cache.f(θ, cache.p)
@@ -149,7 +149,7 @@ function SciMLBase.__solve(cache::Optimization.OptimizationCache{
     end
 
     opt_args = __map_optimizer_args(cache, cache.opt;
-        callback = cache.callback == DEFAULT_CALLBACK &&
+        callback = cache.callback == Optimization.DEFAULT_CALLBACK &&
                    cache.data == Optimization.DEFAULT_DATA ?
                    nothing : _cb,
         cache.solver_args...,

--- a/lib/OptimizationBBO/test/runtests.jl
+++ b/lib/OptimizationBBO/test/runtests.jl
@@ -13,6 +13,8 @@ using Test
     sol = solve(prob, BBO_adaptive_de_rand_1_bin_radiuslimited())
     @test 10 * sol.objective < l1
 
+    @test (@allocated solve(prob, BBO_adaptive_de_rand_1_bin_radiuslimited())) < 1e7
+
     prob = Optimization.OptimizationProblem(optprob, nothing, _p, lb = [-1.0, -1.0],
         ub = [0.8, 0.8])
     sol = solve(prob, BBO_adaptive_de_rand_1_bin_radiuslimited())

--- a/lib/OptimizationOptimisers/src/sophia.jl
+++ b/lib/OptimizationOptimisers/src/sophia.jl
@@ -75,7 +75,7 @@ function SciMLBase.__solve(cache::OptimizationCache{
             return first(cache.f(θ, cache.p))
         elseif cache.callback == Optimization.DEFAULT_CALLBACK
             return first(cache.f(θ, cache.p, cur...))
-        elseif data == Optimization.DEFAULT_DATA
+        elseif data === Optimization.DEFAULT_DATA
             x = cache.f(θ, cache.p)
             return first(x)
         else

--- a/lib/OptimizationOptimisers/src/sophia.jl
+++ b/lib/OptimizationOptimisers/src/sophia.jl
@@ -71,11 +71,11 @@ function SciMLBase.__solve(cache::OptimizationCache{
     maxiters = Optimization._check_and_convert_maxiters(maxiters)
 
     _loss = function (θ)
-        if isnothing(cache.callback) && isnothing(data)
+        if cache.callback == DEFAULT_CALLBACK && data == Optimization.DEFAULT_DATA
             return first(cache.f(θ, cache.p))
-        elseif isnothing(cache.callback)
+        elseif cache.callback == DEFAULT_CALLBACK
             return first(cache.f(θ, cache.p, cur...))
-        elseif isnothing(data)
+        elseif data == Optimization.DEFAULT_DATA
             x = cache.f(θ, cache.p)
             return first(x)
         else

--- a/lib/OptimizationOptimisers/src/sophia.jl
+++ b/lib/OptimizationOptimisers/src/sophia.jl
@@ -71,9 +71,9 @@ function SciMLBase.__solve(cache::OptimizationCache{
     maxiters = Optimization._check_and_convert_maxiters(maxiters)
 
     _loss = function (θ)
-        if cache.callback == DEFAULT_CALLBACK && data == Optimization.DEFAULT_DATA
+        if cache.callback == Optimization.DEFAULT_CALLBACK && data == Optimization.DEFAULT_DATA
             return first(cache.f(θ, cache.p))
-        elseif cache.callback == DEFAULT_CALLBACK
+        elseif cache.callback == Optimization.DEFAULT_CALLBACK
             return first(cache.f(θ, cache.p, cur...))
         elseif data == Optimization.DEFAULT_DATA
             x = cache.f(θ, cache.p)

--- a/lib/OptimizationOptimisers/src/sophia.jl
+++ b/lib/OptimizationOptimisers/src/sophia.jl
@@ -71,9 +71,9 @@ function SciMLBase.__solve(cache::OptimizationCache{
     maxiters = Optimization._check_and_convert_maxiters(maxiters)
 
     _loss = function (θ)
-        if cache.callback == Optimization.DEFAULT_CALLBACK && data == Optimization.DEFAULT_DATA
+        if cache.callback === Optimization.DEFAULT_CALLBACK && data === Optimization.DEFAULT_DATA
             return first(cache.f(θ, cache.p))
-        elseif cache.callback == Optimization.DEFAULT_CALLBACK
+        elseif cache.callback === Optimization.DEFAULT_CALLBACK
             return first(cache.f(θ, cache.p, cur...))
         elseif data === Optimization.DEFAULT_DATA
             x = cache.f(θ, cache.p)

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -52,7 +52,7 @@ struct OptimizationCache{F, RC, LB, UB, LC, UC, S, O, D, P, C} <:
 end
 
 function OptimizationCache(prob::SciMLBase.OptimizationProblem, opt, data;
-    callback = nothing,
+    callback = Optimization.DEFAULT_CALLBACK,
     maxiters::Union{Number, Nothing} = nothing,
     maxtime::Union{Number, Nothing} = nothing,
     abstol::Union{Number, Nothing} = nothing,
@@ -71,7 +71,7 @@ end
 
 function SciMLBase.__init(prob::SciMLBase.OptimizationProblem, opt,
     data = Optimization.DEFAULT_DATA;
-    callback = nothing,
+    callback = Optimization.DEFAULT_CALLBACK,
     maxiters::Union{Number, Nothing} = nothing,
     maxtime::Union{Number, Nothing} = nothing,
     abstol::Union{Number, Nothing} = nothing,

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -1,6 +1,6 @@
 
 function Base.getproperty(cache::SciMLBase.AbstractOptimizationCache, x::Symbol)
-    if x in fieldnames(Optimization.ReInitCache)
+    if x in (:u0, :p)
         return getfield(cache.reinit_cache, x)
     end
     return getfield(cache, x)
@@ -52,7 +52,7 @@ struct OptimizationCache{F, RC, LB, UB, LC, UC, S, O, D, P, C} <:
 end
 
 function OptimizationCache(prob::SciMLBase.OptimizationProblem, opt, data;
-    callback = (args...) -> (false),
+    callback = nothing,
     maxiters::Union{Number, Nothing} = nothing,
     maxtime::Union{Number, Nothing} = nothing,
     abstol::Union{Number, Nothing} = nothing,
@@ -71,7 +71,7 @@ end
 
 function SciMLBase.__init(prob::SciMLBase.OptimizationProblem, opt,
     data = Optimization.DEFAULT_DATA;
-    callback = (args...) -> (false),
+    callback = nothing,
     maxiters::Union{Number, Nothing} = nothing,
     maxtime::Union{Number, Nothing} = nothing,
     abstol::Union{Number, Nothing} = nothing,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,5 @@
+const DEFAULT_CALLBACK = (args...) -> false
+
 struct NullData end
 const DEFAULT_DATA = Iterators.cycle((NullData(),))
 Base.iterate(::NullData, i = 1) = nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,6 @@
-const DEFAULT_CALLBACK = (args...) -> false
+struct NullCallback end
+NullCallback(args) = false;
+const DEFAULT_CALLBACK = NullCallback()
 
 struct NullData end
 const DEFAULT_DATA = Iterators.cycle((NullData(),))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 struct NullCallback end
-NullCallback(args) = false;
+(x::NullCallback)(args...) = false;
 const DEFAULT_CALLBACK = NullCallback()
 
 struct NullData end


### PR DESCRIPTION
This fixes a performance regression due to 92974b8526ca031f9c6ed295462b8a9ba45eeacb. The regression is because the defaults for `callback` and `data` were changed without changing the code that branched on whether they were set to their defaults. 

I removed `fieldnames` as that seems to not run at compile time (it was taking about 50% of the time for my use case due to having to iterate over it), probably because its effects are `(!c,!e,!n,!t,!s,!m,+i)′`. I believe you could fix this by using generated functions but I don't know how to. 
Cthulhu complains that calling `getproperty` with `u0` and `p` has an `Any` return type, though I don't see it in the profiler so maybe Cthulhu is wrong here? If this is an issue, I'm not sure how to fix it, perhaps this feature should be removed.

Some tests should be added to prevent this regression in the future, I've added a test to check for how many bytes are allocated.