### PR TITLE
Remove `syms` and `paramsyms` arguments for `OptimizationFuntion`

### DIFF
--- a/src/function.jl
+++ b/src/function.jl
@@ -97,7 +97,6 @@ function instantiate_function(f, cache::ReInitCache, ::SciMLBase.NoAD,
         cons_jac_prototype = cons_jac_prototype,
         cons_hess_prototype = cons_hess_prototype,
         expr = expr, cons_expr = cons_expr,
-        syms = f.syms, paramsyms = f.paramsyms,
         observed = f.observed)
 end
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

In [this PR](https://github.com/SciML/SciMLBase.jl/commit/bbba9c6ec9c9799ea84db42d6f2fefe061f7ac7d), `syms` and `paramsyms` fields are removed from `OptimizationFunction`. 