### PR TITLE
fix: call `complete` on systems generated in MTKExt

### DIFF
--- a/ext/OptimizationMTKExt.jl
+++ b/ext/OptimizationMTKExt.jl
@@ -10,11 +10,11 @@ function Optimization.instantiate_function(f, x, adtype::AutoModelingToolkit, p,
         num_cons = 0)
     p = isnothing(p) ? SciMLBase.NullParameters() : p
 
-    sys = ModelingToolkit.modelingtoolkitize(OptimizationProblem(f, x, p;
+    sys = complete(ModelingToolkit.modelingtoolkitize(OptimizationProblem(f, x, p;
         lcons = fill(0.0,
             num_cons),
         ucons = fill(0.0,
-            num_cons)))
+            num_cons))))
     #sys = ModelingToolkit.structural_simplify(sys)
     f = OptimizationProblem(sys, x, p, grad = true, hess = true,
         sparse = adtype.obj_sparse, cons_j = true, cons_h = true,
@@ -56,11 +56,11 @@ function Optimization.instantiate_function(f, cache::Optimization.ReInitCache,
         adtype::AutoModelingToolkit, num_cons = 0)
     p = isnothing(cache.p) ? SciMLBase.NullParameters() : cache.p
 
-    sys = ModelingToolkit.modelingtoolkitize(OptimizationProblem(f, cache.u0, cache.p;
+    sys = complete(ModelingToolkit.modelingtoolkitize(OptimizationProblem(f, cache.u0, cache.p;
         lcons = fill(0.0,
             num_cons),
         ucons = fill(0.0,
-            num_cons)))
+            num_cons))))
     #sys = ModelingToolkit.structural_simplify(sys)
     f = OptimizationProblem(sys, cache.u0, cache.p, grad = true, hess = true,
         sparse = adtype.obj_sparse, cons_j = true, cons_h = true,


### PR DESCRIPTION
MTKv9 requires systems to be `complete`d before creating `XProblem`s

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
