### PR TITLE
[OptimizationMOI] fix compat bounds in Project.toml

### DIFF
--- a/lib/OptimizationMOI/Project.toml
+++ b/lib/OptimizationMOI/Project.toml
@@ -4,7 +4,6 @@ authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 version = "0.3.4"
 
 [deps]
-Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
@@ -14,15 +13,22 @@ SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-Ipopt_jll = "=300.1400.400"
+AmplNLWriter = "1"
+HiGHS = "1"
+Ipopt = "1"
+Ipopt_jll = "300.1400"
 Juniper = "0.9"
 MathOptInterface = "1"
 ModelingToolkit = "8.74"
+NLopt = "1"
 Optimization = "3.21"
 Reexport = "1.2"
+SparseArrays = "1.6"
 SymbolicIndexingInterface = "0.3"
 Symbolics = "5"
-julia = "1"
+Test = "1.6"
+Zygote = "0.6"
+julia = "1.6"
 
 [extras]
 AmplNLWriter = "7c4d4715-977e-5154-bfe0-e096adeac482"
@@ -30,10 +36,9 @@ HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 Ipopt_jll = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
 Juniper = "2ddba703-00a4-53a7-87a5-e8b9971dde84"
-ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 NLopt = "76087f3c-5699-56af-9a33-bf431cd00edd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["HiGHS", "Ipopt", "AmplNLWriter", "Ipopt_jll", "ModelingToolkit", "NLopt", "Juniper", "Test", "Zygote"]
+test = ["AmplNLWriter", "HiGHS", "Ipopt", "Ipopt_jll", "Juniper", "NLopt", "Test", "Zygote"]


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

x-ref: https://discourse.julialang.org/t/ac-optimal-power-flow-in-various-nonlinear-optimization-frameworks/78486/88?u=odow

I haven't tested locally, so let's see what CI says.

Ipopt_jll is a test-only dependency. I also added some missing compat bounds. MOI requires Julia 1.6, so the lower Julia bound is now also 1.6.