### PR TITLE
`deepcopy` to save population in default trace, instead of reference

### DIFF
--- a/lib/OptimizationEvolutionary/src/OptimizationEvolutionary.jl
+++ b/lib/OptimizationEvolutionary/src/OptimizationEvolutionary.jl
@@ -18,7 +18,7 @@ function Evolutionary.trace!(tr, iteration, objfun, state, population,
     dt["time"] = curr_time
 
     # record `x` to store the population. Needed for constructing OptimizationState.
-    dt["x"] = population
+    dt["x"] = deepcopy(population)
 
     # set additional trace value
     Evolutionary.trace!(dt, objfun, state, population, method, options)

--- a/lib/OptimizationEvolutionary/test/runtests.jl
+++ b/lib/OptimizationEvolutionary/test/runtests.jl
@@ -50,10 +50,13 @@ Random.seed!(1234)
         record["TESTVAL"] = state.fittest
     end
 
-    #test that `store_trace=true` works now. Threw ""type Array has no field value" before.
+    # Test that `store_trace=true` works now. Threw ""type Array has no field value" before.
     sol = solve(prob, CMAES(μ = 40, λ = 100), store_trace = true)
 
     # Make sure that both the user's trace record value, as well as `x` are stored in the trace.
     @test haskey(sol.original.trace[end].metadata, "TESTVAL") &&
           haskey(sol.original.trace[end].metadata, "x")
+
+    # Test the the values of x are saved, not the reference
+    @test sol.original.trace[end].metadata["x"] !== sol.original.trace[end-1].metadata["x"]
 end


### PR DESCRIPTION
## Default `trace!` overload was saving population by reference

- My previous PR #702 was actually saving a reference to `population` in `trace["x"]`, which was not the intention.
```julia
# Overload the trace! function to add the population to the trace prior to calling any user-defined trace! method
function Evolutionary.trace!(tr, iteration, objfun, state, population,
        method::Evolutionary.AbstractOptimizer, options, curr_time = time())
    dt = Dict{String, Any}()
    dt["time"] = curr_time

    # record `x` to store the population. Needed for constructing OptimizationState.
    dt["x"] = population # HERE

    # set additional trace value
    Evolutionary.trace!(dt, objfun, state, population, method, options)
    Evolutionary.update!(tr,
        state,
        iteration,
        Evolutionary.value(state),
        dt,
        options.store_trace,
        options.show_trace,
        options.show_every,
        options.callback)
end
```

## `deepcopy` fixes the issue
This test fails with the old code, but passes with `deepcopy`:
```julia
# Test the the values of x are saved, not the reference
@test sol.original.trace[end].metadata["x"] !== sol.original.trace[end-1].metadata["x"]
```

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API