### PR TITLE
check identity instead of equality

### DIFF
--- a/lib/OptimizationEvolutionary/test/runtests.jl
+++ b/lib/OptimizationEvolutionary/test/runtests.jl
@@ -58,5 +58,5 @@ Random.seed!(1234)
           haskey(sol.original.trace[end].metadata, "x")
 
     # Test the the values of x are saved, not the reference
-    @test sol.original.trace[end].metadata["x"] !=== sol.original.trace[end-1].metadata["x"]
+    @test !(sol.original.trace[end].metadata["x"] === sol.original.trace[end-1].metadata["x"])
 end

--- a/lib/OptimizationEvolutionary/test/runtests.jl
+++ b/lib/OptimizationEvolutionary/test/runtests.jl
@@ -58,5 +58,5 @@ Random.seed!(1234)
           haskey(sol.original.trace[end].metadata, "x")
 
     # Test the the values of x are saved, not the reference
-    @test sol.original.trace[end].metadata["x"] !== sol.original.trace[end-1].metadata["x"]
+    @test sol.original.trace[end].metadata["x"] !=== sol.original.trace[end-1].metadata["x"]
 end


### PR DESCRIPTION
Previous #730 just tested equality of container, but original issue was about referencing same memory address in each population trace. Functionally the same but thought I'd make a PR
