### PR TITLE
Add tests for Optim.BFGS() with user-supplied grad and bounds

### DIFF
--- a/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
+++ b/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
@@ -95,7 +95,7 @@ function SciMLBase.__init(prob::OptimizationProblem,
                 if prob.f isa OptimizationFunction && (!(prob.f.adtype isa SciMLBase.NoAD) || !isnothing(prob.f.grad))
                     opt = Optim.Fminbox(opt)
                 else
-                    throw(ArgumentError("Fminbox($opt) requires gradients, since you didn't use `OptimizationFunction` with a valid AD backend https://docs.sciml.ai/Optimization/stable/API/ad/ the lower and upper bounds thus will be ignored."))
+                    throw(ArgumentError("Fminbox($opt) requires gradients, use `OptimizationFunction` either with a valid AD backend https://docs.sciml.ai/Optimization/stable/API/ad/ or a provided 'grad' function."))
                 end
             end
         end


### PR DESCRIPTION
Fixes https://github.com/SciML/Optimization.jl/issues/760 https://github.com/SciML/Optimization.jl/issues/755

- add tests for Optim.BFGS() with user-supplied grad and bounds
- fix wording for error message if bounds specified without either grad function or AD

## Checklist

- [ x] Appropriate tests were added
- [ x] Any code changes were done in a way that does not break public API
- [ x] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ x] Any new documentation only uses public API
  
## Additional context


