### PR TITLE
Optimisers iteration count should be calculated with epochs and data both

### DIFF
--- a/lib/OptimizationOptimisers/src/OptimizationOptimisers.jl
+++ b/lib/OptimizationOptimisers/src/OptimizationOptimisers.jl
@@ -80,7 +80,7 @@ function SciMLBase.__solve(cache::OptimizationCache{
 
     t0 = time()
     Optimization.@withprogress cache.progress name="Training" begin
-        for _ in 1:maxiters
+        for epoch in 1:maxiters
             for (i, d) in enumerate(data)
                 if cache.f.fg !== nothing && dataiterate
                     x = cache.f.fg(G, θ, d)
@@ -93,7 +93,7 @@ function SciMLBase.__solve(cache::OptimizationCache{
                     cache.f.grad(G, θ)
                     x = cache.f(θ)
                 end
-                opt_state = Optimization.OptimizationState(iter = i,
+                opt_state = Optimization.OptimizationState(iter = i + (epoch-1)*length(data),
                     u = θ,
                     objective = x[1],
                     grad = G,


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
Fixes #829
Add any other context about the problem here.
