### PR TITLE
MOI Constraint jacobian-vector fixes

### DIFF
--- a/lib/OptimizationMOI/src/nlp.jl
+++ b/lib/OptimizationMOI/src/nlp.jl
@@ -309,6 +309,7 @@ function MOI.eval_constraint_jacobian_product(
     else
         error("Thou shalt provide the v'J of the constraint jacobian, not doing so is associated with great misfortune and also no ice cream for you.")
     end
+    return nothing
 end
 
 function MOI.eval_constraint_jacobian_transpose_product(
@@ -326,6 +327,7 @@ function MOI.eval_constraint_jacobian_transpose_product(
     else
         error("Thou shalt provide the v'J of the constraint jacobian, not doing so is associated with great misfortune and also no ice cream for you.")
     end
+    return nothing
 end
 
 function MOI.hessian_lagrangian_structure(evaluator::MOIOptimizationNLPEvaluator)

--- a/lib/OptimizationMOI/src/nlp.jl
+++ b/lib/OptimizationMOI/src/nlp.jl
@@ -302,14 +302,13 @@ function MOI.eval_constraint_jacobian_product(
         evaluator::MOIOptimizationNLPEvaluator, y, x, w)
     if evaluator.f.cons_jvp !== nothing
         evaluator.f.cons_jvp(y, x, w)
-
     elseif evaluator.f.cons_j !== nothing
         J = evaluator.J
         evaluator.f.cons_j(J, x)
         mul!(y, J, w)
-        return
+    else
+        error("Thou shalt provide the v'J of the constraint jacobian, not doing so is associated with great misfortune and also no ice cream for you.")
     end
-    error("Thou shalt provide the v'J of the constraint jacobian, not doing so is associated with great misfortune and also no ice cream for you.")
 end
 
 function MOI.eval_constraint_jacobian_transpose_product(
@@ -320,14 +319,13 @@ function MOI.eval_constraint_jacobian_transpose_product(
 )
     if evaluator.f.cons_vjp !== nothing
         evaluator.f.cons_vjp(y, x, w)
-
     elseif evaluator.f.cons_j !== nothing
         J = evaluator.J
         evaluator.f.cons_j(J, x)
         mul!(y, J', w)
-        return
+    else
+        error("Thou shalt provide the v'J of the constraint jacobian, not doing so is associated with great misfortune and also no ice cream for you.")
     end
-    error("Thou shalt provide the v'J of the constraint jacobian, not doing so is associated with great misfortune and also no ice cream for you.")
 end
 
 function MOI.hessian_lagrangian_structure(evaluator::MOIOptimizationNLPEvaluator)

--- a/lib/OptimizationMOI/test/runtests.jl
+++ b/lib/OptimizationMOI/test/runtests.jl
@@ -47,14 +47,14 @@ end
     @test (evaluator.f.cons_j !== nothing) || (evaluator.f.cons_jvp !== nothing)
     y = zeros(1)
     w = ones(2)
-    @test MathOptInterface.eval_constraint_jacobian_product(evaluator, y, x, w) isa Any
+    @test MathOptInterface.eval_constraint_jacobian_product(evaluator, y, x, w) === nothing
 
     # constraint jacobian-vector product
     @test (evaluator.f.cons_j !== nothing) || (evaluator.f.cons_vjp !== nothing)
     y = zeros(2)
     w = ones(1)
     @test MathOptInterface.eval_constraint_jacobian_transpose_product(
-        evaluator, y, x, w) isa Any
+        evaluator, y, x, w) === nothing
 end
 
 @testset "NLP" begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

It seems that the methods `MOI.eval_constraint_jacobian_transpose_product` and `MOI.eval_constraint_jacobian_product` were incorrectly both evaluating the products and erroring when the evaluator possessed `cons_vjp` or `cons_jvp` functions. 

Add any other context about the problem here.
