### PR TITLE
Update OptimizationOptimisers.jl

### DIFF
--- a/lib/OptimizationOptimisers/src/OptimizationOptimisers.jl
+++ b/lib/OptimizationOptimisers/src/OptimizationOptimisers.jl
@@ -130,12 +130,12 @@ function SciMLBase.__solve(cache::OptimizationCache{
                         min_err = x
                         min_θ = copy(θ)
                     end
-                    if i == length(data)*epochs  #Last iter, revert to best.
+                    if iterations == length(data)*epochs  #Last iter, revert to best.
                         opt = min_opt
                         x = min_err
                         θ = min_θ
                         cache.f.grad(G, θ, d)
-                        opt_state = Optimization.OptimizationState(iter = i,
+                        opt_state = Optimization.OptimizationState(iter = iterations,
                             u = θ,
                             objective = x[1],
                             grad = G,


### PR DESCRIPTION
Modify check for last iteration to set the parameters to the best minimizer if save_best if enabled.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

When save_best is enabled, the last iteration would set the solution to the best minimizer. The check for that was updated to reflect the changes made after the maxiters and epochs args. 