### PR TITLE
Check more retcodes from NLopt

### DIFF
--- a/lib/OptimizationNLopt/test/runtests.jl
+++ b/lib/OptimizationNLopt/test/runtests.jl
@@ -145,6 +145,6 @@ using Test, Random
             ucons = [0.0, 0.0], lb = [-1.0, -1.0], ub = [1.0, 1.0])
         sol = solve(prob, NLopt.GN_ISRES(), maxiters = 1000)
         @test sol.retcode == ReturnCode.MaxIters
-        @test 10 * sol.objective < l1
+        @test sol.objective < l1
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -100,8 +100,10 @@ function deduce_retcode(retcode::Symbol)
         return ReturnCode.Default
     elseif retcode == :Success || retcode == :EXACT_SOLUTION_LEFT ||
            retcode == :FLOATING_POINT_LIMIT || retcode == :true || retcode == :OPTIMAL ||
-           retcode == :LOCALLY_SOLVED || retcode == :ROUNDOFF_LIMITED || retcode == :SUCCESS ||
-           retcode == :STOPVAL_REACHED || retcode == :FTOL_REACHED || retcode == :XTOL_REACHED
+           retcode == :LOCALLY_SOLVED || retcode == :ROUNDOFF_LIMITED ||
+           retcode == :SUCCESS ||
+           retcode == :STOPVAL_REACHED || retcode == :FTOL_REACHED ||
+           retcode == :XTOL_REACHED
         return ReturnCode.Success
     elseif retcode == :Terminated
         return ReturnCode.Terminated

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -100,14 +100,15 @@ function deduce_retcode(retcode::Symbol)
         return ReturnCode.Default
     elseif retcode == :Success || retcode == :EXACT_SOLUTION_LEFT ||
            retcode == :FLOATING_POINT_LIMIT || retcode == :true || retcode == :OPTIMAL ||
-           retcode == :LOCALLY_SOLVED || retcode == :ROUNDOFF_LIMITED || retcode == :SUCCESS
+           retcode == :LOCALLY_SOLVED || retcode == :ROUNDOFF_LIMITED || retcode == :SUCCESS ||
+           retcode == :STOPVAL_REACHED || retcode == :FTOL_REACHED || retcode == :XTOL_REACHED
         return ReturnCode.Success
     elseif retcode == :Terminated
         return ReturnCode.Terminated
     elseif retcode == :MaxIters || retcode == :MAXITERS_EXCEED ||
            retcode == :MAXEVAL_REACHED
         return ReturnCode.MaxIters
-    elseif retcode == :MaxTime || retcode == :TIME_LIMIT
+    elseif retcode == :MaxTime || retcode == :TIME_LIMIT || retcode == :MAXTIME_REACHED
         return ReturnCode.MaxTime
     elseif retcode == :DtLessThanMin
         return ReturnCode.DtLessThanMin


### PR DESCRIPTION
This change covers all successful termination return codes listed in NLopt documentation (https://nlopt.readthedocs.io/en/latest/NLopt_Reference/#successful-termination-positive-return-values).

A test in OptimizationNLopt will follow.

Closes #862.