### PR TITLE
Fix nested bullet list in optimization.md

### DIFF
--- a/docs/src/optimization_packages/optimization.md
+++ b/docs/src/optimization_packages/optimization.md
@@ -4,28 +4,28 @@ There are some solvers that are available in the Optimization.jl package directl
 
 ## Methods
 
-  - `LBFGS`: The popular quasi-Newton method that leverages limited memory BFGS approximation of the inverse of the Hessian. Through a wrapper over the [L-BFGS-B](https://users.iems.northwestern.edu/%7Enocedal/lbfgsb.html) fortran routine accessed from the [LBFGSB.jl](https://github.com/Gnimuc/LBFGSB.jl/) package. It directly supports box-constraints.
+- `LBFGS`: The popular quasi-Newton method that leverages limited memory BFGS approximation of the inverse of the Hessian. Through a wrapper over the [L-BFGS-B](https://users.iems.northwestern.edu/%7Enocedal/lbfgsb.html) fortran routine accessed from the [LBFGSB.jl](https://github.com/Gnimuc/LBFGSB.jl/) package. It directly supports box-constraints.
 
-This can also handle arbitrary non-linear constraints through a Augmented Lagrangian method with bounds constraints described in 17.4 of Numerical Optimization by Nocedal and Wright. Thus serving as a general-purpose nonlinear optimization solver available directly in Optimization.jl.
+  This can also handle arbitrary non-linear constraints through a Augmented Lagrangian method with bounds constraints described in 17.4 of Numerical Optimization by Nocedal and Wright. Thus serving as a general-purpose nonlinear optimization solver available directly in Optimization.jl.
 
-  - `Sophia`: Based on the recent paper https://arxiv.org/abs/2305.14342. It incorporates second order information in the form of the diagonal of the Hessian matrix hence avoiding the need to compute the complete hessian. It has been shown to converge faster than other first order methods such as Adam and SGD.
+- `Sophia`: Based on the recent paper https://arxiv.org/abs/2305.14342. It incorporates second order information in the form of the diagonal of the Hessian matrix hence avoiding the need to compute the complete hessian. It has been shown to converge faster than other first order methods such as Adam and SGD.
     
-        + `solve(problem, Sophia(; η, βs, ϵ, λ, k, ρ))`
-    
-        + `η` is the learning rate
-        + `βs` are the decay of momentums
-        + `ϵ` is the epsilon value
-        + `λ` is the weight decay parameter
-        + `k` is the number of iterations to re-compute the diagonal of the Hessian matrix
-        + `ρ` is the momentum
-        + Defaults:
-    
-            * `η = 0.001`
-            * `βs = (0.9, 0.999)`
-            * `ϵ = 1e-8`
-            * `λ = 0.1`
-            * `k = 10`
-            * `ρ = 0.04`
+  + `solve(problem, Sophia(; η, βs, ϵ, λ, k, ρ))`
+
+  + `η` is the learning rate
+  + `βs` are the decay of momentums
+  + `ϵ` is the epsilon value
+  + `λ` is the weight decay parameter
+  + `k` is the number of iterations to re-compute the diagonal of the Hessian matrix
+  + `ρ` is the momentum
+  + Defaults:
+
+    * `η = 0.001`
+    * `βs = (0.9, 0.999)`
+    * `ϵ = 1e-8`
+    * `λ = 0.1`
+    * `k = 10`
+    * `ρ = 0.04`
 
 ## Examples
 


### PR DESCRIPTION
The mismatched indents were breaking the markdown list and having parsers read some sub-lists as code blocks.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Minor doc fix
