### PR TITLE
Simplify calls to Optim.jl

### DIFF
--- a/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
+++ b/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
@@ -421,7 +421,7 @@ function SciMLBase.__solve(cache::OptimizationCache{
     lb = cache.lb === nothing ? [] : cache.lb
     ub = cache.ub === nothing ? [] : cache.ub
 
-    optim_fc = if SciMLBase.requireshessian(opt)
+    optim_fc = if SciMLBase.requireshessian(cache.opt)
         if cache.f.cons !== nothing
             Optim.TwiceDifferentiableConstraints(cache.f.cons, cache.f.cons_j,
                 cons_hl!,

--- a/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
+++ b/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
@@ -432,7 +432,7 @@ function SciMLBase.__solve(cache::OptimizationCache{
         end
     else
         if cache.f.cons !== nothing
-            Optim.OnceDifferentiableConstraints(cache.f.cons, cache.f.cons_j
+            Optim.OnceDifferentiableConstraints(cache.f.cons, cache.f.cons_j,
                 lb, ub,
                 cache.lcons, cache.ucons)
         else


### PR DESCRIPTION
Much of the complexity in the issues with the Optim.jl wrapper is simply because it doesn't treat Optim well. It makes things always complete, instead of simplifying the call. This simplifies the call, so the less you use the less machinery is required. In particular:

* TwiceDifferentiable is only made and used if the optimizer needs to use Hessians. This fixes https://github.com/SciML/Optimization.jl/issues/859, fixes https://github.com/SciML/Optimization.jl/issues/893
* Only uses constraints and bounds when the user sets them. Fixes https://github.com/SciML/Optimization.jl/issues/863 and fixes https://github.com/SciML/Optimization.jl/issues/558
