### PR TITLE
Fix LBFGS iteration counter always showing 0

### DIFF
--- a/src/lbfgsb.jl
+++ b/src/lbfgsb.jl
@@ -116,13 +116,15 @@ function SciMLBase.__solve(cache::OptimizationCache{
         cache.f.cons(cons_tmp, cache.u0)
         ρ = max(1e-6, min(10, 2 * (abs(cache.f(cache.u0, cache.p))) / norm(cons_tmp)))
 
+        iter_count = Ref(0)
         _loss = function (θ)
             x = cache.f(θ, cache.p)
+            iter_count[] += 1
             cons_tmp .= zero(eltype(θ))
             cache.f.cons(cons_tmp, θ)
             cons_tmp[eq_inds] .= cons_tmp[eq_inds] - cache.lcons[eq_inds]
             cons_tmp[ineq_inds] .= cons_tmp[ineq_inds] .- cache.ucons[ineq_inds]
-            opt_state = Optimization.OptimizationState(u = θ, objective = x[1])
+            opt_state = Optimization.OptimizationState(u = θ, objective = x[1], iter = iter_count[])
             if cache.callback(opt_state, x...)
                 error("Optimization halted by callback.")
             end
@@ -206,10 +208,12 @@ function SciMLBase.__solve(cache::OptimizationCache{
             cache, cache.opt, res[2], cache.f(res[2], cache.p)[1],
             stats = stats, retcode = opt_ret)
     else
+        iter_count = Ref(0)
         _loss = function (θ)
             x = cache.f(θ, cache.p)
+            iter_count[] += 1
 
-            opt_state = Optimization.OptimizationState(u = θ, objective = x[1])
+            opt_state = Optimization.OptimizationState(u = θ, objective = x[1], iter = iter_count[])
             if cache.callback(opt_state, x...)
                 error("Optimization halted by callback.")
             end


### PR DESCRIPTION
## Summary

Fixes #907 - This PR fixes the LBFGS solver's iteration counter which was always showing 0 in callbacks.

## Problem

When using callbacks with `Optimization.LBFGS()`, the `opt_state.iter` value was always 0, making it impossible to track optimization progress. This was inconsistent with other solvers like Adam which properly increment the iteration counter.

Example from the issue:
```julia
callback = (opt_state, loss_val) -> (println(opt_state.iter); false;)
sol = solve(prob, Optimization.LBFGS(); callback, maxiters = 10)
# Prints: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0...
```

## Solution

Added iteration tracking using a `Ref` counter that increments with each loss function evaluation:
- Added `iter_count = Ref(0)` before the `_loss` function definition
- Increment `iter_count[]` inside the loss function
- Pass `iter_count[]` to the `OptimizationState` constructor
- Applied the fix to both constrained and unconstrained optimization cases

## Testing

Tested with the example from the issue:
```julia
callback = (opt_state, loss_val) -> (println(opt_state.iter); false;)
sol = solve(prob, Optimization.LBFGS(); callback, maxiters = 10)
# Now prints: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
```

The iteration counter now properly increments, matching the behavior of other solvers.

🤖 Generated with [Claude Code](https://claude.ai/code)