### PR TITLE
Add support for dual_ftol_rel parameter in NLopt

### DIFF
--- a/lib/OptimizationNLopt/src/OptimizationNLopt.jl
+++ b/lib/OptimizationNLopt/src/OptimizationNLopt.jl
@@ -93,7 +93,12 @@ function __map_optimizer_args!(cache::OptimizationCache, opt::NLopt.Opt;
     # add optimiser options from kwargs
     for j in kwargs
         if j.first != :cons_tol
-            eval(Meta.parse("NLopt." * string(j.first) * "!"))(opt, j.second)
+            # Handle special parameters that use nlopt_set_param
+            if j.first == :dual_ftol_rel
+                NLopt.nlopt_set_param(opt, "dual_ftol_rel", j.second)
+            else
+                eval(Meta.parse("NLopt." * string(j.first) * "!"))(opt, j.second)
+            end
         end
     end
 


### PR DESCRIPTION
## Summary

Fixes #922 - This PR adds support for the `dual_ftol_rel` parameter in OptimizationNLopt, which is used by MMA/CCSA algorithms to control the dual optimization subproblem tolerance.

## Problem

When trying to use the `dual_ftol_rel` parameter with NLopt solvers like `LD_CCSAQ`, users would get an error:
```julia
sol = solve(prob, NLopt.LD_CCSAQ(), xtol_rel = 1e-7, dual_ftol_rel = 1e-7)
# ERROR: UndefVarError: `dual_ftol_rel\!` not defined
```

This happened because the code was trying to call `NLopt.dual_ftol_rel\!()` which doesn't exist. The `dual_ftol_rel` is not a direct setter function but a named parameter in NLopt.

## Solution

Added special handling for `dual_ftol_rel` in the `__map_optimizer_args\!` function:
- Check if the keyword argument is `dual_ftol_rel`
- If yes, use `NLopt.nlopt_set_param(opt, "dual_ftol_rel", value)` instead of the generic eval approach
- Otherwise, continue with the existing behavior

## Why this matters

From the NLopt documentation:
> Because this subsidiary solve requires no evaluations of the user's objective function, it is typically fast enough that it can be solved to high precision without worrying too much about the details. However, in high-dimensional problems you may notice that MMA/CCSA is taking a long time between optimization steps, in which case you may want to increase dual_ftol_rel or make other changes.

This parameter is particularly important for users working with high-dimensional optimization problems using MMA or CCSA algorithms.

## Testing

Verified that:
- The parameter can now be set without errors
- The fix uses the correct NLopt API (`nlopt_set_param`)
- Backward compatibility is maintained for all other parameters

🤖 Generated with [Claude Code](https://claude.ai/code)