### PR TITLE
Add downgrade CI workflow with Core test group

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,34 @@
+name: Downgrade
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        downgrade_mode: ['alldeps']
+        julia-version: ['1.10']
+        group: ['Core']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/julia-downgrade-compat@v2
+        with:
+          skip: Pkg,TOML
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          ALLOW_RERESOLVE: false
+        env:
+          GROUP: ${{ matrix.group }}


### PR DESCRIPTION
## Summary
- Adds standardized downgrade CI workflow following SciMLBase.jl template
- Configured to run the Core test group for lean, focused testing
- Tests package compatibility with downgraded dependencies using julia-downgrade-compat@v2
- Uses ALLOW_RERESOLVE: false as required for downgrade v2

## Test plan
- [ ] Verify CI workflow triggers on pull requests and pushes to master
- [ ] Confirm downgrade testing works with Core test group
- [ ] Check that workflow follows SciML ecosystem standards

🤖 Generated with [Claude Code](https://claude.ai/code)