### PR TITLE
Add error message when NLopt AUGLAG algorithms are used without local_method

### DIFF
--- a/lib/OptimizationNLopt/src/OptimizationNLopt.jl
+++ b/lib/OptimizationNLopt/src/OptimizationNLopt.jl
@@ -68,6 +68,15 @@ function __map_optimizer_args!(cache::OptimizationCache, opt::NLopt.Opt;
         local_maxtime::Union{Number, Nothing} = nothing,
         local_options::Union{NamedTuple, Nothing} = nothing,
         kwargs...)
+
+    # Check if AUGLAG algorithm requires local_method
+    alg_str = string(opt.algorithm)
+    if occursin("AUGLAG", alg_str) && local_method === nothing
+        error("NLopt.$(opt.algorithm) requires a local optimization method. " *
+              "Please specify a local_method, e.g., solve(prob, NLopt.$(opt.algorithm)(); " *
+              "local_method = NLopt.LN_NELDERMEAD())")
+    end
+
     if local_method !== nothing
         if isa(local_method, NLopt.Opt)
             if ndims(local_method) != length(cache.u0)

--- a/lib/OptimizationNLopt/src/OptimizationNLopt.jl
+++ b/lib/OptimizationNLopt/src/OptimizationNLopt.jl
@@ -70,8 +70,7 @@ function __map_optimizer_args!(cache::OptimizationCache, opt::NLopt.Opt;
         kwargs...)
 
     # Check if AUGLAG algorithm requires local_method
-    alg_str = string(opt.algorithm)
-    if occursin("AUGLAG", alg_str) && local_method === nothing
+    if opt.algorithm ∈ (NLopt.LN_AUGLAG, NLopt.LD_AUGLAG, NLopt.AUGLAG) && local_method === nothing
         error("NLopt.$(opt.algorithm) requires a local optimization method. " *
               "Please specify a local_method, e.g., solve(prob, NLopt.$(opt.algorithm)(); " *
               "local_method = NLopt.LN_NELDERMEAD())")

--- a/lib/OptimizationNLopt/test/runtests.jl
+++ b/lib/OptimizationNLopt/test/runtests.jl
@@ -149,6 +149,10 @@ using Test, Random
         # @test sol.retcode == ReturnCode.Success
         @test 10 * sol.objective < l1
 
+        # Test that AUGLAG without local_method throws an error
+        @test_throws ErrorException solve(prob, NLopt.LN_AUGLAG())
+        @test_throws ErrorException solve(prob, NLopt.LD_AUGLAG())
+
         function con2_c(res, x, p)
             res .= [x[1]^2 + x[2]^2 - 1.0, x[2] * sin(x[1]) - x[1] - 2.0]
         end


### PR DESCRIPTION
## Summary
Fixes #1020 

This PR adds a clear error message when NLopt's AUGLAG algorithms are used without specifying a `local_method` parameter, preventing undefined behavior.

## Problem
As reported in #1020 and confirmed by @ChrisRackauckas, NLopt's AUGLAG algorithms require a local optimization method to function properly. When used without one:
- The algorithm returns incorrect results (e.g., `[0.0, 0.0]` with `Inf` objective)
- This is undefined behavior that should not be allowed

## Solution
- Added validation in `__map_optimizer_args!` to check if an AUGLAG algorithm is being used without a `local_method`
- Throws a descriptive error message with usage example when this condition is detected
- Added test cases to verify the error is thrown for both `LN_AUGLAG` and `LD_AUGLAG`

## Test plan
✅ All existing tests pass
✅ Added specific test cases for the error condition
✅ Manually verified the fix resolves the issue described in #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)