### PR TITLE
Bump OptimizationBase requirement to v3 and increment sublibrary versions

### DIFF
--- a/lib/OptimizationAuglag/Project.toml
+++ b/lib/OptimizationAuglag/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationAuglag"
 uuid = "2ea93f80-9333-43a1-a68d-1f53b957a421"
 authors = ["paramthakkar123 <paramthakkar864@gmail.com>"]
-version = "1.0.0"
+version = "1.1.0"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -18,7 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ForwardDiff = "1.0.1"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 MLUtils = "0.4.8"
 OptimizationOptimisers = "0.3.8"
 Test = "1.10.0"

--- a/lib/OptimizationBBO/Project.toml
+++ b/lib/OptimizationBBO/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationBBO"
 uuid = "3e6eede4-6085-4f62-9a71-46d9bc1eb92b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.4.2"
+version = "0.4.3"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -18,7 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 julia = "1.10"
 BlackBoxOptim = "0.6"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 SciMLBase = "2.58"
 Reexport = "1.2"
 

--- a/lib/OptimizationCMAEvolutionStrategy/Project.toml
+++ b/lib/OptimizationCMAEvolutionStrategy/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationCMAEvolutionStrategy"
 uuid = "bd407f91-200f-4536-9381-e4ba712f53f8"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.2"
+version = "0.3.3"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -18,7 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 CMAEvolutionStrategy = "0.2"
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 SciMLBase = "2.58"
 Reexport = "1.2"
 

--- a/lib/OptimizationEvolutionary/Project.toml
+++ b/lib/OptimizationEvolutionary/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationEvolutionary"
 uuid = "cb963754-43f6-435e-8d4b-99009ff27753"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.4.2"
+version = "0.4.3"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -18,7 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 Evolutionary = "0.11"
 SciMLBase = "2.58"
 Reexport = "1.2"

--- a/lib/OptimizationGCMAES/Project.toml
+++ b/lib/OptimizationGCMAES/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationGCMAES"
 uuid = "6f0a0517-dbc2-4a7a-8a20-99ae7f27e911"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -18,7 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 SciMLBase = "2.58"
 Reexport = "1.2"
 GCMAES = "0.1"

--- a/lib/OptimizationIpopt/Project.toml
+++ b/lib/OptimizationIpopt/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationIpopt"
 uuid = "43fad042-7963-4b32-ab19-e2a4f9a67124"
 authors = ["Sebastian Micluța-Câmpeanu <sebastian.mc95@proton.me> and contributors"]
-version = "0.2.2"
+version = "0.2.3"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -18,7 +18,7 @@ SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 Ipopt = "1.10.3"
 LinearAlgebra = "1.10.0"
 ModelingToolkit = "10.23"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 SciMLBase = "2.90.0"
 SparseArrays = "1.10.0"
 SymbolicIndexingInterface = "0.3.40"

--- a/lib/OptimizationLBFGSB/Project.toml
+++ b/lib/OptimizationLBFGSB/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationLBFGSB"
 uuid = "22f7324a-a79d-40f2-bebe-3af60c77bd15"
 authors = ["paramthakkar123 <paramthakkar864@gmail.com>"]
-version = "1.0.0"
+version = "1.1.0"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -23,7 +23,7 @@ DocStringExtensions = "0.9.5"
 ForwardDiff = "1.0.1"
 LBFGSB = "0.4.1"
 MLUtils = "0.4.8"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 SciMLBase = "2.58"
 Zygote = "0.7.10"
 julia = "1.10"

--- a/lib/OptimizationMOI/Project.toml
+++ b/lib/OptimizationMOI/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationMOI"
 uuid = "fd9f6733-72f4-499f-8506-86b2bdd0dea1"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.5.7"
+version = "0.5.8"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -31,7 +31,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 HiGHS = "1"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 Test = "1.6"
 Symbolics = "6"
 AmplNLWriter = "1"

--- a/lib/OptimizationManopt/Project.toml
+++ b/lib/OptimizationManopt/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationManopt"
 uuid = "e57b7fff-7ee7-4550-b4f0-90e9476e9fb6"
 authors = ["Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "1.0.0"
+version = "1.1.0"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -30,7 +30,7 @@ Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 [compat]
 julia = "1.10"
 Manopt = "0.5"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 LinearAlgebra = "1.10"
 ManifoldsBase = "1"
 ManifoldDiff = "0.4"

--- a/lib/OptimizationMetaheuristics/Project.toml
+++ b/lib/OptimizationMetaheuristics/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationMetaheuristics"
 uuid = "3aafef2f-86ae-4776-b337-85a36adf0b55"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.2"
+version = "0.3.3"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -18,7 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 Metaheuristics = "3"
 SciMLBase = "2.58"
 Reexport = "1.2"

--- a/lib/OptimizationMultistartOptimization/Project.toml
+++ b/lib/OptimizationMultistartOptimization/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationMultistartOptimization"
 uuid = "e4316d97-8bbb-4fd3-a7d8-3851d2a72823"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -21,7 +21,7 @@ OptimizationNLopt = "4e6fcdb7-1186-4e1f-a706-475e75c168bb"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 MultistartOptimization = "0.2, 0.3"
 SciMLBase = "2.58"
 Reexport = "1.2"

--- a/lib/OptimizationNLPModels/Project.toml
+++ b/lib/OptimizationNLPModels/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationNLPModels"
 uuid = "064b21be-54cf-11ef-1646-cdfee32b588f"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.0.2"
+version = "0.0.3"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -26,7 +26,7 @@ OptimizationOptimJL = "36348300-93cb-4f02-beb5-3c3902f8871e"
 julia = "1.10"
 NLPModels = "0.21"
 ADTypes = "1.7"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 SciMLBase = "2.58"
 Reexport = "1.2"
 

--- a/lib/OptimizationNLopt/Project.toml
+++ b/lib/OptimizationNLopt/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationNLopt"
 uuid = "4e6fcdb7-1186-4e1f-a706-475e75c168bb"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.4"
+version = "0.3.5"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -20,7 +20,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 NLopt = "1.1"
 SciMLBase = "2.58"
 Reexport = "1.2"

--- a/lib/OptimizationNOMAD/Project.toml
+++ b/lib/OptimizationNOMAD/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationNOMAD"
 uuid = "2cab0595-8222-4775-b714-9828e6a9e01b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.2"
+version = "0.3.3"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -17,7 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 NOMAD = "2.4.1"
 SciMLBase = "2.58"
 Reexport = "1.2"

--- a/lib/OptimizationODE/Project.toml
+++ b/lib/OptimizationODE/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationODE"
 uuid = "dfa73e59-e644-4d8a-bf84-188d7ecb34e4"
 authors = ["Paras Puneet Singh <paras.puneet2204@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -20,7 +20,7 @@ NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 [compat]
 DiffEqBase = "6.190"
 ForwardDiff = "0.10, 1"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 OrdinaryDiffEq = "6.70"
 NonlinearSolve = "4"
 Reexport = "1"

--- a/lib/OptimizationOptimJL/Project.toml
+++ b/lib/OptimizationOptimJL/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationOptimJL"
 uuid = "36348300-93cb-4f02-beb5-3c3902f8871e"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.4.5"
+version = "0.4.6"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -25,7 +25,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 [compat]
 julia = "1.10"
 PrecompileTools = "1.2"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 SparseArrays = "1.6"
 Optim = "1"
 Reexport = "1.2"

--- a/lib/OptimizationOptimisers/Project.toml
+++ b/lib/OptimizationOptimisers/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationOptimisers"
 uuid = "42dfb2eb-d2b4-4451-abcd-913932933ac1"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.11"
+version = "0.3.12"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -26,7 +26,7 @@ Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 ProgressLogging = "0.1"
 SciMLBase = "2.58"
 Optimisers = "0.2, 0.3, 0.4"

--- a/lib/OptimizationPRIMA/Project.toml
+++ b/lib/OptimizationPRIMA/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationPRIMA"
 uuid = "72f8369c-a2ea-4298-9126-56167ce9cbc2"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -20,7 +20,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 PRIMA = "0.2.0"
 SciMLBase = "2.58"
 Reexport = "1"

--- a/lib/OptimizationPolyalgorithms/Project.toml
+++ b/lib/OptimizationPolyalgorithms/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationPolyalgorithms"
 uuid = "500b13db-7e66-49ce-bda4-eed966be6282"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -19,7 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 OptimizationOptimisers = "0.3"
 SciMLBase = "2.58"
 Reexport = "1.2"

--- a/lib/OptimizationPyCMA/Project.toml
+++ b/lib/OptimizationPyCMA/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationPyCMA"
 uuid = "fb0822aa-1fe5-41d8-99a6-e7bf6c238d3b"
 authors = ["Maximilian Pochapski <67759684+mxpoch@users.noreply.github.com>"]
-version = "1.1.0"
+version = "1.2.0"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -16,7 +16,7 @@ PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 CondaPkg = "0.2"
 Test = "1.10"
 SciMLBase = "2.58"

--- a/lib/OptimizationQuadDIRECT/Project.toml
+++ b/lib/OptimizationQuadDIRECT/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationQuadDIRECT"
 uuid = "842ac81e-713d-465f-80f7-84eddaced298"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -18,7 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 SciMLBase = "2.58"
 Reexport = "1.2"
 

--- a/lib/OptimizationSciPy/Project.toml
+++ b/lib/OptimizationSciPy/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationSciPy"
 uuid = "cce07bd8-c79b-4b00-aee8-8db9cce22837"
 authors = ["Aditya Pandey <adityapand3y666@gmail.com> and contributors"]
-version = "0.4.2"
+version = "0.4.3"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -22,7 +22,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 SciMLBase = "2.58"
 Reexport = "1.2"
 PythonCall = "0.9"

--- a/lib/OptimizationSophia/Project.toml
+++ b/lib/OptimizationSophia/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationSophia"
 uuid = "892fee11-dca1-40d6-b698-84ba0d87399a"
 authors = ["paramthakkar123 <paramthakkar864@gmail.com>"]
-version = "1.0.0"
+version = "1.1.0"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -24,7 +24,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 ComponentArrays = "0.15.29"
 Lux = "1.16.0"
 MLUtils = "0.4.8"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 OrdinaryDiffEqTsit5 = "1.2.0"
 Random = "1.10.0"
 SciMLBase = "2.58"

--- a/lib/OptimizationSpeedMapping/Project.toml
+++ b/lib/OptimizationSpeedMapping/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationSpeedMapping"
 uuid = "3d669222-0d7d-4eb9-8a9f-d8528b0d9b91"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [sources]
 OptimizationBase = {path = "../OptimizationBase"}
@@ -18,7 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "2.13"
+OptimizationBase = "3"
 SpeedMapping = "0.3"
 SciMLBase = "2.58"
 Reexport = "1.2"


### PR DESCRIPTION
## Summary

This PR updates all Optimization.jl sublibraries to require OptimizationBase v3 instead of v2.13, and increments the version numbers of all sublibraries according to semantic versioning conventions.

## Changes

### Version Requirement Updates
- Updated all sublibraries to require `OptimizationBase = "3"` instead of `OptimizationBase = "2.13"`

### Version Bumps
Following the convention where:
- Packages with version ≥ 1.0.0 get a minor version bump (x.y.z → x.(y+1).0)
- Packages with version < 1.0.0 get a patch version bump (0.y.z → 0.y.(z+1))

#### Packages bumped to next minor version (≥ 1.0.0):
- OptimizationAuglag: 1.0.0 → 1.1.0
- OptimizationLBFGSB: 1.0.0 → 1.1.0
- OptimizationManopt: 1.0.0 → 1.1.0
- OptimizationPyCMA: 1.1.0 → 1.2.0
- OptimizationSophia: 1.0.0 → 1.1.0

#### Packages bumped to next patch version (< 1.0.0):
- OptimizationBBO: 0.4.2 → 0.4.3
- OptimizationCMAEvolutionStrategy: 0.3.2 → 0.3.3
- OptimizationEvolutionary: 0.4.2 → 0.4.3
- OptimizationGCMAES: 0.3.1 → 0.3.2
- OptimizationIpopt: 0.2.2 → 0.2.3
- OptimizationMetaheuristics: 0.3.2 → 0.3.3
- OptimizationMOI: 0.5.7 → 0.5.8
- OptimizationMultistartOptimization: 0.3.1 → 0.3.2
- OptimizationNLopt: 0.3.4 → 0.3.5
- OptimizationNLPModels: 0.0.2 → 0.0.3
- OptimizationNOMAD: 0.3.2 → 0.3.3
- OptimizationODE: 0.1.2 → 0.1.3
- OptimizationOptimisers: 0.3.11 → 0.3.12
- OptimizationOptimJL: 0.4.5 → 0.4.6
- OptimizationPolyalgorithms: 0.3.1 → 0.3.2
- OptimizationPRIMA: 0.3.1 → 0.3.2
- OptimizationQuadDIRECT: 0.3.1 → 0.3.2
- OptimizationSciPy: 0.4.2 → 0.4.3
- OptimizationSpeedMapping: 0.2.1 → 0.2.2

## Notes

- No changes were made to the top-level Optimization.jl package as requested
- OptimizationBase itself was not modified since this PR only updates dependencies on it
- All 24 sublibraries have been updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)