### PR TITLE
Fix deprecated field names in MultistartOptimization result handling

### DIFF
--- a/lib/OptimizationMultistartOptimization/src/OptimizationMultistartOptimization.jl
+++ b/lib/OptimizationMultistartOptimization/src/OptimizationMultistartOptimization.jl
@@ -62,7 +62,7 @@ function SciMLBase.__solve(cache::OptimizationBase.OptimizationCache{
     _local_optimiser = function (pb, θ0, prob)
         prob_tmp = remake(prob, u0 = θ0)
         res = solve(prob_tmp, cache.solver_args.local_opt)
-        return (value = res.minimum, location = res.minimizer, ret = res.retcode)
+        return (value = res.objective, location = res.u, ret = res.retcode)
     end
 
     local_optimiser(pb, θ0) = _local_optimiser(pb, θ0, cache.solver_args.prob)


### PR DESCRIPTION
## Summary

Fixes deprecation warnings when using `MultistartOptimization.TikTak` by updating to use current OptimizationSolution field names.

## Changes

Updates the `_local_optimiser` function in `OptimizationMultistartOptimization.jl` to use the current field names for optimization results:
- Changed `res.minimum` → `res.objective`
- Changed `res.minimizer` → `res.u`

## Context

This resolves deprecation warnings that appeared during testing and ensures compatibility with the current OptimizationSolution API. The issue was mentioned in [Discourse thread #133174](https://discourse.julialang.org/t/error-when-using-multistart-optimization/133174).

The traits for `MultistartOptimization.TikTak` are already correctly set:
- `requiresbounds = true` (TikTak needs bounds for Sobol sequence generation)
- `allowsbounds = true` (TikTak supports bounds and passes them to local optimizer)

## Test plan

- [x] Ran `Pkg.test("OptimizationMultistartOptimization")` - all tests pass without deprecation warnings
- [x] Verified the fix eliminates the deprecation warnings that were present before
- [x] Formatted code with SciMLStyle

🤖 Generated with [Claude Code](https://claude.com/claude-code)