### PR TITLE
Fix OptimizationIpopt & OptimizationMOI with OptimizationBase@v3

### DIFF
--- a/lib/OptimizationIpopt/Project.toml
+++ b/lib/OptimizationIpopt/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationIpopt"
 uuid = "43fad042-7963-4b32-ab19-e2a4f9a67124"
 authors = ["Sebastian Micluța-Câmpeanu <sebastian.mc95@proton.me> and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 [deps]
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/OptimizationIpopt/src/OptimizationIpopt.jl
+++ b/lib/OptimizationIpopt/src/OptimizationIpopt.jl
@@ -170,6 +170,11 @@ function SciMLBase.has_init(alg::IpoptOptimizer)
     true
 end
 
+# Compatibility with OptimizationBase@v3
+function SciMLBase.supports_opt_cache_interface(alg::IpoptOptimizer)
+    true
+end
+
 function SciMLBase.requiresgradient(opt::IpoptOptimizer)
     true
 end

--- a/lib/OptimizationMOI/Project.toml
+++ b/lib/OptimizationMOI/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationMOI"
 uuid = "fd9f6733-72f4-499f-8506-86b2bdd0dea1"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.5.9"
+version = "0.5.10"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"

--- a/lib/OptimizationMOI/src/OptimizationMOI.jl
+++ b/lib/OptimizationMOI/src/OptimizationMOI.jl
@@ -288,6 +288,12 @@ function SciMLBase.has_init(alg::Union{MOI.AbstractOptimizer,
     true
 end
 
+# Compatibility with OptimizationBase@v3
+function SciMLBase.supports_opt_cache_interface(alg::Union{MOI.AbstractOptimizer,
+        MOI.OptimizerWithAttributes})
+    true
+end
+
 function SciMLBase.__init(prob::OptimizationProblem,
         opt::Union{MOI.AbstractOptimizer, MOI.OptimizerWithAttributes};
         maxiters::Union{Number, Nothing} = nothing,


### PR DESCRIPTION
I messed up the update for OptimizationMOI & OptimizationIpopt, as they are compatible with both v3 and v4 since they use their own cache type. I don't think there's a reason to do that anymore and they should use the OptimizaitonCache, but untill then, we can support both versions by defining the `SciMLBase.supports_opt_cache_interface` (we need the SciMLBsae function, not the OptimizationBase one since OptimizationBase [calls the SciMLBase version](https://github.com/SciML/Optimization.jl/blob/6b9527c3923b19c253d27a53bec04a23d178dcfb/lib/OptimizationBase/src/solve.jl#L95)).