### PR TITLE
build: bump minor versions for packages changed in MTKv11 update

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Optimization"
 uuid = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
-version = "5.2.0"
+version = "5.3.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -51,7 +51,7 @@ Optim = ">= 1.4.1"
 Optimisers = ">= 0.2.5"
 OptimizationBase = "4"
 OptimizationLBFGSB = "1.2"
-OptimizationMOI = "0.5.9"
+OptimizationMOI = "0.6"
 OptimizationOptimJL = "0.4.7"
 OptimizationOptimisers = "0.3.14"
 OrdinaryDiffEqTsit5 = "1"

--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "4.0.2"
+version = "4.1.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OptimizationIpopt/Project.toml
+++ b/lib/OptimizationIpopt/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationIpopt"
 uuid = "43fad042-7963-4b32-ab19-e2a4f9a67124"
 authors = ["Sebastian Micluța-Câmpeanu <sebastian.mc95@proton.me> and contributors"]
-version = "0.2.6"
+version = "0.3.0"
 [deps]
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/OptimizationMOI/Project.toml
+++ b/lib/OptimizationMOI/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationMOI"
 uuid = "fd9f6733-72f4-499f-8506-86b2bdd0dea1"
-version = "0.5.11"
+version = "0.6.0"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]

--- a/lib/OptimizationMadNLP/Project.toml
+++ b/lib/OptimizationMadNLP/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationMadNLP"
 uuid = "5d9c809f-c847-4062-9fba-1793bbfef577"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Sebastian Micluța-Câmpeanu <sebastian.mc95@proton.me> and contributors"]
 
 [deps]
@@ -20,7 +20,7 @@ LinearAlgebra = "1.10.0"
 MadNLP = "0.8.12"
 ModelingToolkit = "11"
 NLPModels = "0.21.5"
-OptimizationBase = "4.0.2"
+OptimizationBase = "4.1"
 Reexport = "1.2"
 SciMLBase = "2.122.1"
 SparseArrays = "1.10.0"


### PR DESCRIPTION
## Summary

Bump minor versions for packages that were modified in #1107 (MTKv11 update):

| Package | Old Version | New Version |
|---------|-------------|-------------|
| Optimization.jl | 5.2.0 | 5.3.0 |
| OptimizationBase | 4.0.2 | 4.1.0 |
| OptimizationIpopt | 0.2.6 | 0.3.0 |
| OptimizationMOI | 0.5.11 | 0.6.0 |
| OptimizationMadNLP | 0.3.0 | 0.4.0 |

Also updates compat bounds:
- `OptimizationMOI` compat in main `Project.toml`: `0.5.9` → `0.6`
- `OptimizationBase` compat in `OptimizationMadNLP/Project.toml`: `4.0.2` → `4.1`

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)