### PR TITLE
Fix evolutionary optimizers not working with bounds

### DIFF
--- a/lib/OptimizationEvolutionary/src/OptimizationEvolutionary.jl
+++ b/lib/OptimizationEvolutionary/src/OptimizationEvolutionary.jl
@@ -152,12 +152,16 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {
         else
             cons = BoxConstraints(cache.lb, cache.ub)
         end
+        # When bounds are provided, don't pass the initial point to allow
+        # Evolutionary.jl to generate a random initial population within the bounds.
+        # Passing the initial point causes the population to be copies of that point,
+        # which prevents proper exploration of the search space.
         if isa(f, MultiObjectiveOptimizationFunction)
             opt_res = Evolutionary.optimize(
-                _loss, _loss(cache.u0), cons, cache.u0, cache.opt, opt_args
+                _loss, _loss(cache.u0), cons, cache.opt, opt_args
             )
         else
-            opt_res = Evolutionary.optimize(_loss, cons, cache.u0, cache.opt, opt_args)
+            opt_res = Evolutionary.optimize(_loss, cons, cache.opt, opt_args)
         end
     end
     t1 = time()

--- a/lib/OptimizationEvolutionary/test/runtests.jl
+++ b/lib/OptimizationEvolutionary/test/runtests.jl
@@ -13,13 +13,18 @@ Random.seed!(1234)
     sol = solve(prob, CMAES(μ = 40, λ = 100), abstol = 1.0e-15)
     @test 10 * sol.objective < l1
 
+    # Test with bounds - initial point is outside bounds, but algorithm should
+    # generate a random initial population within the bounds and find a good solution
     x0 = [-0.7, 0.3]
     prob = OptimizationBase.OptimizationProblem(
         optprob, x0, _p, lb = [0.0, 0.0],
         ub = [0.5, 0.5]
     )
     sol = solve(prob, CMAES(μ = 50, λ = 60))
-    @test sol.u == zeros(2)
+    # Within bounds [0,0.5]x[0,0.5], the minimum of Rosenbrock is at approximately
+    # [0.5, 0.25] with f ≈ 0.25, which is much better than f([0,0]) = 1.0
+    @test sol.objective < 1.0
+    @test all(sol.u .>= 0.0) && all(sol.u .<= 0.5)
 
     x0 = zeros(2)
     cons_circ = (res, x, p) -> res .= [x[1]^2 + x[2]^2]


### PR DESCRIPTION
## Summary

- Fixed bug where evolutionary optimizers (GA, DE, etc.) would not properly explore the search space when bounds are provided
- When bounds are specified, the initial population is now generated randomly within the bounds instead of being copies of the initial point

## Problem

As reported in #1151, evolutionary optimizers in OptimizationEvolutionary would only evaluate the objective function with the initial parameters and then return early, reporting success despite having a large objective value. The optimizers were not actually exploring the search space.

## Root Cause

When calling `Evolutionary.optimize(_loss, cons, cache.u0, cache.opt, opt_args)` with both constraints and an initial point, Evolutionary.jl uses the initial point to generate the population by copying it `population_size` times. This means all population members start at the same point, and with small mutations, they stay near that point without properly exploring the bounded region.

## Solution

When bounds are provided (BoxConstraints or WorstFitnessConstraints with bounds), don't pass the initial point to Evolutionary.jl. This allows Evolutionary.jl to generate a random initial population within the specified bounds using its `initial_population(method, bounds::ConstraintBounds)` function.

## Test Results

Before fix (GA with bounds on Rosenbrock):
```
GA Result: u = [0.0, 0.0], objective = 1.0
iterations: 12, f_calls: 650
```

After fix (GA with bounds on Rosenbrock):
```
GA Result: u = [0.67, 0.36], objective = 0.77
iterations: 12, f_calls: 650
```

After fix (DE with bounds on Rosenbrock):
```
DE Result: u = [1.0, 1.0], objective = 2.27e-11
iterations: 106, f_calls: 5300
```

## Test plan

- [x] Existing OptimizationEvolutionary tests pass (32/32)
- [x] Updated the bounds test to verify the solution is within bounds and has improved objective
- [x] Manual testing with GA, DE, and CMAES algorithms confirms proper optimization behavior

🤖 Generated with [Claude Code](https://claude.ai/claude-code)