### PR TITLE
Improve return codes from OptimizationManopt

### DIFF
--- a/lib/OptimizationManopt/src/OptimizationManopt.jl
+++ b/lib/OptimizationManopt/src/OptimizationManopt.jl
@@ -37,8 +37,9 @@ function __map_optimizer_args!(
         push!(criteria, Manopt.StopAfter(maxtime))
     end
 
-    tol = isnothing(abstol) ? 1e-8 : abstol
-    push!(criteria, _default_convergence_criterion(opt, manifold, tol))
+    if !isnothing(abstol)
+        push!(criteria, _default_convergence_criterion(opt, manifold, abstol))
+    end
 
     if !isnothing(reltol)
         @SciMLMessage(
@@ -366,15 +367,15 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: AbstractMano
         hessF = build_hessF(cache.f)
     end
 
-    if haskey(solver_kwarg, :stopping_criterion)
-        stopping_criterion = Manopt.StopWhenAny(solver_kwarg.stopping_criterion...)
+    stopping_kwarg = if haskey(solver_kwarg, :stopping_criterion)
+        (; stopping_criterion = Manopt.StopWhenAny(solver_kwarg.stopping_criterion...))
     else
-        stopping_criterion = Manopt.StopAfterIteration(500)
+        (;)
     end
 
     opt_res = call_manopt_optimizer(
         manifold, cache.opt, _loss, gradF, cache.u0;
-        solver_kwarg..., stopping_criterion = stopping_criterion, hessF
+        solver_kwarg..., stopping_kwarg..., hessF
     )
 
     asc = get_stopping_criterion(opt_res.options)

--- a/lib/OptimizationManopt/src/OptimizationManopt.jl
+++ b/lib/OptimizationManopt/src/OptimizationManopt.jl
@@ -34,7 +34,7 @@ function __map_optimizer_args!(
     end
 
     if !isnothing(maxtime)
-        push!(criteria, Manopt.StopAfterTime(maxtime))
+        push!(criteria, Manopt.StopAfter(maxtime))
     end
 
     tol = isnothing(abstol) ? 1e-8 : abstol
@@ -378,10 +378,17 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: AbstractMano
     )
 
     asc = get_stopping_criterion(opt_res.options)
+    active = Manopt.get_active_stopping_criteria(asc)
     opt_ret = if Manopt.has_converged(asc)
         ReturnCode.Success
-    elseif any(c -> c isa Manopt.StopAfterIteration, Manopt.get_active_stopping_criteria(asc))
+    elseif any(c -> c isa Manopt.StopAfterIteration, active)
         ReturnCode.MaxIters
+    elseif any(c -> c isa Manopt.StopAfter, active)
+        ReturnCode.MaxTime
+    elseif any(c -> c isa Union{Manopt.StopWhenCostNaN, Manopt.StopWhenIterateNaN}, active)
+        ReturnCode.Unstable
+    elseif any(c -> c isa Manopt.StopWhenStepsizeLess, active)
+        ReturnCode.Stalled
     else
         ReturnCode.Failure
     end

--- a/lib/OptimizationManopt/src/OptimizationManopt.jl
+++ b/lib/OptimizationManopt/src/OptimizationManopt.jl
@@ -18,7 +18,8 @@ OptimizationBase.supports_sense(::AbstractManoptOptimizer) = true
 
 function __map_optimizer_args!(
         cache::OptimizationBase.OptimizationCache,
-        opt::AbstractManoptOptimizer;
+        opt::AbstractManoptOptimizer,
+        manifold;
         callback = nothing,
         maxiters::Union{Number, Nothing} = nothing,
         maxtime::Union{Number, Nothing} = nothing,
@@ -26,49 +27,29 @@ function __map_optimizer_args!(
         reltol::Union{Number, Nothing} = nothing,
         kwargs...
     )
-    solver_kwargs = (; kwargs...)
+    criteria = Manopt.StoppingCriterion[]
 
     if !isnothing(maxiters)
-        solver_kwargs = (;
-            solver_kwargs..., stopping_criterion = [Manopt.StopAfterIteration(maxiters)],
-        )
+        push!(criteria, Manopt.StopAfterIteration(maxiters))
     end
 
     if !isnothing(maxtime)
-        if haskey(solver_kwargs, :stopping_criterion)
-            solver_kwargs = (;
-                solver_kwargs...,
-                stopping_criterion = push!(
-                    solver_kwargs.stopping_criterion, Manopt.StopAfterTime(maxtime)
-                ),
-            )
-        else
-            solver_kwargs = (;
-                solver_kwargs..., stopping_criterion = [Manopt.StopAfter(maxtime)],
-            )
-        end
+        push!(criteria, Manopt.StopAfterTime(maxtime))
     end
 
-    if !isnothing(abstol)
-        if haskey(solver_kwargs, :stopping_criterion)
-            solver_kwargs = (;
-                solver_kwargs...,
-                stopping_criterion = push!(
-                    solver_kwargs.stopping_criterion, Manopt.StopWhenChangeLess(abstol)
-                ),
-            )
-        else
-            solver_kwargs = (;
-                solver_kwargs..., stopping_criterion = [Manopt.StopWhenChangeLess(abstol)],
-            )
-        end
-    end
+    tol = isnothing(abstol) ? 1e-8 : abstol
+    push!(criteria, _default_convergence_criterion(opt, manifold, tol))
 
     if !isnothing(reltol)
         @SciMLMessage(
             lazy"common reltol is currently not used by $(typeof(opt).super)",
             cache.verbose, :unsupported_kwargs
         )
+    end
+
+    solver_kwargs = (; kwargs...)
+    if !isempty(criteria)
+        solver_kwargs = (; solver_kwargs..., stopping_criterion = criteria)
     end
     return solver_kwargs
 end
@@ -283,6 +264,20 @@ function SciMLBase.requireshessian(
     return true
 end
 
+const GradientBasedManoptOptimizer = Union{
+    GradientDescentOptimizer, ConjugateGradientDescentOptimizer,
+    QuasiNewtonOptimizer, ConvexBundleOptimizer, FrankWolfeOptimizer,
+    AdaptiveRegularizationCubicOptimizer, TrustRegionsOptimizer,
+}
+
+function _default_convergence_criterion(::GradientBasedManoptOptimizer, M, abstol)
+    return Manopt.StopWhenGradientNormLess(abstol)
+end
+
+function _default_convergence_criterion(::AbstractManoptOptimizer, M, abstol)
+    return Manopt.StopWhenChangeLess(M, abstol)
+end
+
 function build_loss(f::OptimizationFunction, prob, cb)
     # TODO: I do not understand this. Why is the manifold not used?
     # Either this is an Euclidean cost, then we should probably still call `embed`,
@@ -353,11 +348,11 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: AbstractMano
         return cb_call
     end
     solver_kwarg = __map_optimizer_args!(
-        cache, cache.opt, callback = _cb,
+        cache, cache.opt, manifold; callback = _cb,
         maxiters = cache.solver_args.maxiters,
         maxtime = cache.solver_args.maxtime,
         abstol = cache.solver_args.abstol,
-        reltol = cache.solver_args.reltol;
+        reltol = cache.solver_args.reltol,
         cache.solver_args...
     )
 
@@ -383,7 +378,13 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: AbstractMano
     )
 
     asc = get_stopping_criterion(opt_res.options)
-    opt_ret = Manopt.has_converged(asc) ? ReturnCode.Success : ReturnCode.Failure
+    opt_ret = if Manopt.has_converged(asc)
+        ReturnCode.Success
+    elseif any(c -> c isa Manopt.StopAfterIteration, Manopt.get_active_stopping_criteria(asc))
+        ReturnCode.MaxIters
+    else
+        ReturnCode.Failure
+    end
 
     return SciMLBase.build_solution(
         cache,

--- a/lib/OptimizationManopt/test/runtests.jl
+++ b/lib/OptimizationManopt/test/runtests.jl
@@ -162,7 +162,7 @@ R2 = Euclidean(2)
 
         sol = OptimizationBase.solve(prob, opt)
         @test sol.objective < 0.1
-        @test SciMLBase.successful_retcode(sol) broken = true
+        @test SciMLBase.successful_retcode(sol)
     end
 
     @testset "TrustRegions" begin
@@ -178,7 +178,7 @@ R2 = Euclidean(2)
 
         sol = OptimizationBase.solve(prob, opt)
         @test sol.objective < 0.1
-        @test SciMLBase.successful_retcode(sol) broken = true
+        @test SciMLBase.successful_retcode(sol)
     end
 
     @testset "Custom constraints" begin


### PR DESCRIPTION
Fix the convergence criteria
- only add convergence criterion via explicit abstol
- Use the Manopt convergence criteria when tolerances are not explicitly provided.

Map additional Manopt stopping criteria to specific SciML return codes:
- StopAfter (time limit) → ReturnCode.MaxTime
- StopWhenCostNaN/StopWhenIterateNaN → ReturnCode.Unstable
- StopWhenStepsizeLess → ReturnCode.Stalled

Fixes #1034

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
