### PR TITLE
fix: add warning for abstol on ipopt algorithm

### DIFF
--- a/lib/OptimizationIpopt/src/OptimizationIpopt.jl
+++ b/lib/OptimizationIpopt/src/OptimizationIpopt.jl
@@ -298,6 +298,12 @@ function __map_optimizer_args(
 
     # Override with common interface arguments if provided
     optkeys = keys(opt.additional_options)
+    if !isnothing(abstol)
+        @SciMLMessage(
+            lazy"common abstol is currently not used by $(opt)",
+            verbose, :unsupported_kwargs
+        )
+    end
     !isnothing(reltol) && !in("tol", optkeys) && Ipopt.AddIpoptNumOption(prob, "tol", reltol)
     !isnothing(maxiters) && !in("max_iter", optkeys) && Ipopt.AddIpoptIntOption(prob, "max_iter", maxiters)
     !isnothing(maxtime) && !in("max_wall_time", optkeys) && Ipopt.AddIpoptNumOption(prob, "max_wall_time", Float64(maxtime))


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
This PR adds a warning when the user sets the absolute tolerance in ipopt, as this parameter is not used in the algorithm.