### PR TITLE
CI: retry Pkg.test() once on transient PythonCall init failures

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -149,8 +149,45 @@ jobs:
             end
           end
 
+          # Pkg.test() with one retry on transient PythonCall precompile
+          # init failures (UndefRefError inside PythonCall.JlWrap.__init__
+          # during deserialization). This has been observed intermittently
+          # on the OptimizationSciPy and OptimizationPyCMA jobs and is not
+          # caused by a code change in this repository — see PythonCall
+          # issue tracker for the upstream root cause. Other failure modes
+          # are rethrown immediately.
+          function _pythoncall_init_failure(e)
+            msg = sprint(showerror, e)
+            return occursin("PythonCall", msg) &&
+                   (occursin("JlWrap", msg) || occursin("UndefRefError", msg))
+          end
+
+          function run_tests_with_retry()
+            try
+              Pkg.test()
+            catch e
+              if _pythoncall_init_failure(e)
+                @warn "Transient PythonCall init failure detected; clearing compile cache and retrying once" exception=(e, catch_backtrace())
+                # Drop the stale precompile cache that triggered the failed
+                # __init__ so the retry rebuilds it from scratch.
+                for depot in DEPOT_PATH
+                  compiled = joinpath(depot, "compiled")
+                  isdir(compiled) || continue
+                  for entry in ("PythonCall", "OptimizationSciPy", "OptimizationPyCMA",
+                                "SciMLBasePythonCallExt")
+                    path = joinpath(compiled, "v$(VERSION.major).$(VERSION.minor)", entry)
+                    isdir(path) && rm(path; recursive = true, force = true)
+                  end
+                end
+                Pkg.test()
+              else
+                rethrow()
+              end
+            end
+          end
+
           @info "Starting tests"
-          Pkg.test()
+          run_tests_with_retry()
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,lib/OptimizationBase/src,lib/OptimizationBBO/src,lib/OptimizationCMAEvolutionStrategy/src,lib/OptimizationEvolutionary/src,lib/OptimizationGCMAES/src,lib/OptimizationIpopt/src,lib/OptimizationMadNLP/src,lib/OptimizationManopt/src,lib/OptimizationMOI/src,lib/OptimizationMetaheuristics/src,lib/OptimizationMultistartOptimization/src,lib/OptimizationNLopt/src,lib/OptimizationNOMAD/src,lib/OptimizationOptimJL/src,lib/OptimizationOptimisers/src,lib/OptimizationPolyalgorithms/src,lib/OptimizationQuadDIRECT/src,lib/OptimizationSpeedMapping/src


### PR DESCRIPTION
## Summary
The `OptimizationSciPy` (and occasionally `OptimizationPyCMA`) jobs intermittently fail at the precompile stage with

```
InitError: UndefRefError: access to undefined reference
 [11] __init__()
    @ PythonCall.JlWrap ~/.julia/packages/PythonCall/.../src/JlWrap/JlWrap.jl:70
during initialization of module JlWrap
in expression starting at .../OptimizationSciPy/src/OptimizationSciPy.jl:2
```

This happens with the same `PythonCall` version (`v0.9.31`) on runs where other jobs succeed — e.g. `OptimizationSciPy, lts` **passes** on master run [`24144818227`](https://github.com/SciML/Optimization.jl/actions/runs/24144818227) but the same job **fails** on PR #1169 run [`23171032225`](https://github.com/SciML/Optimization.jl/actions/runs/23171032225/job/67322715053?pr=1169). It's an upstream PythonCall flakiness around precompile cache deserialization, not a code change in this repository.

## Approach
Wrap `Pkg.test()` so that, on a `PythonCall` + `JlWrap` / `UndefRefError`-shaped exception:

1. The precompile cache directories for `PythonCall`, `OptimizationSciPy`, `OptimizationPyCMA`, and `SciMLBasePythonCallExt` are removed (they're what carry the stale `JlWrap` state across runs).
2. `Pkg.test()` is retried **exactly once**.

Any other exception is rethrown immediately, so genuine test failures are still surfaced. The retry only fires when the error matches **both** `PythonCall` and one of `JlWrap` / `UndefRefError`, so it will not mask unrelated test bugs in any group.

## Test plan
- [x] Detection function unit-tested locally against the CI error string and against unrelated `BoundsError` / generic `ErrorException` (only the PythonCall init shape returns `true`)
- [x] Embedded Julia script parses (`Meta.parseall`) cleanly
- [x] YAML validates with `yaml.safe_load`
- [ ] Live CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)