### PR TITLE
test/minibatch: use Float64 for time, state, and parameters

### DIFF
--- a/test/minibatch.jl
+++ b/test/minibatch.jl
@@ -24,9 +24,9 @@ function callback(state, l) #callback function to observe training
     return l < 1.0e-2
 end
 
-u0 = Float32[200.0]
+u0 = [200.0]
 datasize = 30
-tspan = (0.0f0, 1.5f0)
+tspan = (0.0, 1.5)
 
 t = range(tspan[1], tspan[2], length = datasize)
 true_prob = ODEProblem(true_sol, u0, tspan)
@@ -34,7 +34,7 @@ ode_data = Array(solve(true_prob, Tsit5(), saveat = t))
 
 ann = Lux.Chain(Lux.Dense(1, 8, tanh), Lux.Dense(8, 1, tanh))
 pp, st = Lux.setup(rng, ann)
-pp = ComponentArray(pp)
+pp = ComponentArray{Float64}(pp)
 
 prob = ODEProblem{false}(dudt_, u0, tspan, pp)
 


### PR DESCRIPTION
## Summary
The minibatch test was using `Float32` for `u0`, `tspan`, and the network parameters (via the default `Lux.setup` eltype). It is a test of the minibatching loop, not of Float32 throughput, and the Float32 choice exposes a fragile codepath in `SciMLSensitivity`'s `InterpolatingAdjoint` checkpoint re-solve.

## What's actually going wrong on master
This is the failure currently surfacing in [`test (Core, 1.11)`](https://github.com/SciML/Optimization.jl/actions/runs/24144818227) on master and on PR #1169:

```
Mini batching: Error During Test
  LoadError: BoundsError: attempt to access 1-element Vector{Float32} at index [0]
   [3] split_states(du, u, t, S::ODEInterpolatingAdjointSensitivityFunction{...})
       @ SciMLSensitivity .../src/interpolating_adjoint.jl:241
```

Instrumenting `SciMLSensitivity.split_states` shows the cpsol-length pattern repeating as `2, 2, 3, 1, 2, 2, 3, 1, …` every 4 sub-checkpoint intervals:

```
length=2 interval=(1.40, 1.45) cpsol_t=[1.4482758, 1.5]
length=2 interval=(1.34, 1.40) cpsol_t=[1.3965517, 1.4482758]
length=3 interval=(1.29, 1.34) cpsol_t=[1.3448275, 1.3965516, 1.3965517]   ← !
length=1 interval=(1.24, 1.29) cpsol_t=[1.2931035]                          ← BoundsError
```

The chain:
1. The InterpolatingAdjoint sub-checkpoint forward re-solve seeds its initial `dt` with `abs(cpsol_t[end] - cpsol_t[end - 1])` from the previous re-solve.
2. With `Float32` time, an adaptive Tsit5 step that lands one ulp past `interval[2]` is followed by a tiny "correction" step back to `interval[2]`, leaving the last two `cpsol_t` entries 1 ulp apart (~1.2e-7).
3. That ulp value becomes the `dt` for the next re-solve over an interval ~0.052 wide. The Tsit5 controller, given that microscopic seed, ends up emitting a `cpsol` whose time vector has only the start point.
4. On the iteration after that, `cpsol_t[end - 1]` becomes `cpsol_t[0]` and the test errors out.

`Float64` has ~1e-16 epsilon, so the same ulp-collision pattern produces a `dt` far below any `abstol`/`reltol` the controller cares about, and the feedback loop never amplifies into a 1-point cpsol.

## Test plan
- [x] Reproduced the original `BoundsError` locally against the registered, **unpatched** SciMLSensitivity `v7.103.0`
- [x] `test/minibatch.jl` runs to completion against the same registered `v7.103.0` after this Float64 change
- [x] No mixed-precision warnings (Lux network params are now `ComponentArray{Float64}` so the matmuls are pure Float64)

## Notes
A related defensive fix in `SciMLSensitivity.split_states` (guarding `cpsol_t[end - 1]` against `length(cpsol_t) < 2`) is up at SciML/SciMLSensitivity.jl#1413. With this PR landed, that one becomes optional — hardening only, since `Float64` time alone makes the bad codepath unreachable from this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)