### PR TITLE
CI: serialize precompile workers for python-using groups

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,6 +64,14 @@ jobs:
             ${{ runner.os }}-test-${{ matrix.version }}-${{ env.cache-name }}-
             ${{ runner.os }}-test-${{ matrix.version }}-
             ${{ runner.os }}-
+      # Serialize precompile workers for the python-using groups. PythonCall's
+      # `JlWrap.__init__` has been observed to fail intermittently with
+      # `UndefRefError: access to undefined reference` when multiple precompile
+      # workers spin up the wrapper-type registration concurrently. Setting
+      # `JULIA_NUM_PRECOMPILE_TASKS=1` removes that race; the cost on these
+      # small subpackages is negligible.
+      - if: ${{ matrix.group == 'OptimizationSciPy' || matrix.group == 'OptimizationPyCMA' }}
+        run: echo "JULIA_NUM_PRECOMPILE_TASKS=1" >> $GITHUB_ENV
       - uses: julia-actions/julia-buildpkg@v1
       - if: ${{ matrix.group == 'OptimizationQuadDIRECT' }}
         run: julia --project -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url  = "https://github.com/HolyLab/HolyLabRegistry.git")); Pkg.add("QuadDIRECT")'


### PR DESCRIPTION
## Summary
Replaces #1180 (closed) with a substantive non-retry fix.

The `OptimizationSciPy` (and occasionally `OptimizationPyCMA`) jobs have been observed to fail at the precompile stage with

```
InitError: UndefRefError: access to undefined reference
 [1] _pyjl_new(t::Ptr{...}, ::Ptr{...}, ::Ptr{...})
     @ PythonCall.JlWrap.Cjl ~/.julia/packages/PythonCall/.../JlWrap/C.jl:24
 ...
[11] __init__()
     @ PythonCall.JlWrap ~/.julia/packages/PythonCall/.../JlWrap/JlWrap.jl:70
during initialization of module JlWrap
in expression starting at .../OptimizationSciPy/src/OptimizationSciPy.jl:2
```

with the **same** `PythonCall v0.9.31` on which other CI runs succeed — `OptimizationSciPy, lts` **passes** on master run [`24144818227`](https://github.com/SciML/Optimization.jl/actions/runs/24144818227) but the **same** job **fails** on PR #1169 run [`23171032225`](https://github.com/SciML/Optimization.jl/actions/runs/23171032225/job/67322715053?pr=1169).

## Root cause
The intermittency + identical package versions + failure happening inside PythonCall's own wrapper-type registration in `JlWrap.__init__` all point at a **parallel precompile race**. `JlWrap.__init__` (`.../src/JlWrap/JlWrap.jl:54-75`) does

```julia
function __init__()
    init_base()
    init_raw()
    init_any()
    ...
    init_module()
    ...
    jl = pyjuliacallmodule
    jl.Core = Base.Core      # ← line 70: pysetattr → _pyjl_new
    jl.Base = Base
    jl.Main = Main
    ...
end
```

When multiple precompile workers spin up wrapper-type registration concurrently, one observes a not-yet-populated Python type slot inside `_pyjl_new` and throws `UndefRefError`. This explains the every-N-th-run flake without any other moving parts.

## Fix
`Pkg.precompile()` reads `JULIA_NUM_PRECOMPILE_TASKS` ([Julia base/precompilation.jl:437](https://github.com/JuliaLang/julia/blob/v1.11.9/base/precompilation.jl#L437)) to size its parallel-task semaphore. Setting it to `1` serializes precompile workers and removes the race.

```yaml
- if: ${{ matrix.group == 'OptimizationSciPy' || matrix.group == 'OptimizationPyCMA' }}
  run: echo "JULIA_NUM_PRECOMPILE_TASKS=1" >> $GITHUB_ENV
```

Targeted to **OptimizationSciPy** and **OptimizationPyCMA** only. Other groups keep their default parallel precompile, so there's no global slowdown. The cost on these small python-wrapping subpackages is a few seconds.

## Why not retry
A retry-on-failure approach (#1180) would have masked the race instead of removing it. Subsequent failures of unrelated bugs in those groups would also have been silently retried. Per maintainer feedback, `JULIA_NUM_PRECOMPILE_TASKS=1` is the more honest, targeted fix.

## Test plan
- [x] `JULIA_NUM_PRECOMPILE_TASKS=1` confirmed to be read by Julia 1.11 (`base/precompilation.jl:437`)
- [x] YAML validates with `yaml.safe_load`
- [x] Conditional `if:` block scoped to the two python-using groups only
- [ ] Live CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)