### PR TITLE
Fix OptimizationPRIMA retcode mapping — was always Success

### DIFF
--- a/lib/OptimizationPRIMA/src/OptimizationPRIMA.jl
+++ b/lib/OptimizationPRIMA/src/OptimizationPRIMA.jl
@@ -109,21 +109,25 @@ function __map_optimizer_args!(
     return kws
 end
 
-function sciml_prima_retcode(rc::AbstractString)
-    if rc in [
-            "SMALL_TR_RADIUS", "TRSUBP_FAILED", "NAN_INF_X", "NAN_INF_F", "NAN_INF_MODEL",
-            "DAMAGING_ROUNDING", "ZERO_LINEAR_CONSTRAINT", "INVALID_INPUT", "ASSERTION_FAILS",
-            "VALIDATION_FAILS", "MEMORY_ALLOCATION_FAILS",
-        ]
-        return ReturnCode.Failure
-    else
-        rc in [
-            "FTARGET_ACHIEVED"
-            "MAXFUN_REACHED"
-            "MAXTR_REACHED"
-            "NO_SPACE_BETWEEN_BOUNDS"
-        ]
+function sciml_prima_retcode(status::PRIMA.Status)
+    # PRIMA's own success predicate (PRIMA/src/PRIMA.jl):
+    #     issuccess(status) = status == SMALL_TR_RADIUS || status == FTARGET_ACHIEVED
+    if status == PRIMA.FTARGET_ACHIEVED || status == PRIMA.SMALL_TR_RADIUS
         return ReturnCode.Success
+    elseif status == PRIMA.MAXFUN_REACHED || status == PRIMA.MAXTR_REACHED
+        return ReturnCode.MaxIters
+    elseif status == PRIMA.NO_SPACE_BETWEEN_BOUNDS ||
+            status == PRIMA.ZERO_LINEAR_CONSTRAINT ||
+            status == PRIMA.INVALID_INPUT
+        return ReturnCode.InitialFailure
+    elseif status == PRIMA.NAN_INF_X || status == PRIMA.NAN_INF_F ||
+            status == PRIMA.NAN_INF_MODEL
+        return ReturnCode.Unstable
+    elseif status == PRIMA.DAMAGING_ROUNDING
+        return ReturnCode.ConvergenceFailure
+    else
+        # TRSUBP_FAILED, ASSERTION_FAILS, VALIDATION_FAILS, MEMORY_ALLOCATION_FAILS
+        return ReturnCode.Failure
     end
 end
 
@@ -201,7 +205,7 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: PRIMASolvers
     end
     t1 = time()
 
-    retcode = sciml_prima_retcode(PRIMA.reason(inf))
+    retcode = sciml_prima_retcode(inf.status)
     stats = OptimizationBase.OptimizationStats(; time = t1 - t0, fevals = inf.nf)
     return SciMLBase.build_solution(
         cache, cache.opt, minx,

--- a/lib/OptimizationPRIMA/test/runtests.jl
+++ b/lib/OptimizationPRIMA/test/runtests.jl
@@ -1,4 +1,5 @@
 using OptimizationPRIMA, OptimizationBase, ForwardDiff, ModelingToolkit, ReverseDiff
+using OptimizationBase: SciMLBase
 using Test
 
 @testset "OptimizationPRIMA.jl" begin
@@ -10,15 +11,44 @@ using Test
     prob = OptimizationProblem(rosenbrock, x0, _p)
     sol = OptimizationBase.solve(prob, UOBYQA(), maxiters = 1000)
     @test 10 * sol.objective < l1
+    @test sol.retcode == SciMLBase.ReturnCode.Success
     sol = OptimizationBase.solve(prob, NEWUOA(), maxiters = 1000)
     @test 10 * sol.objective < l1
+    @test sol.retcode == SciMLBase.ReturnCode.Success
     sol = OptimizationBase.solve(prob, BOBYQA(), maxiters = 1000)
     @test 10 * sol.objective < l1
+    @test sol.retcode == SciMLBase.ReturnCode.Success
     sol = OptimizationBase.solve(prob, LINCOA(), maxiters = 1000)
     @test 10 * sol.objective < l1
+    @test sol.retcode == SciMLBase.ReturnCode.Success
     @test_throws OptimizationBase.IncompatibleOptimizerError OptimizationBase.solve(
         prob, COBYLA(), maxiters = 1000
     )
+
+    # Force MaxIters with a very small iteration budget — also exercises a
+    # non-FTARGET_ACHIEVED/SMALL_TR_RADIUS return path.
+    sol_maxit = OptimizationBase.solve(prob, UOBYQA(), maxiters = 3)
+    @test sol_maxit.retcode == SciMLBase.ReturnCode.MaxIters
+
+    @testset "sciml_prima_retcode enum mapping" begin
+        m = OptimizationPRIMA.sciml_prima_retcode
+        # PRIMA treats both SMALL_TR_RADIUS and FTARGET_ACHIEVED as success.
+        @test m(PRIMA.FTARGET_ACHIEVED) == SciMLBase.ReturnCode.Success
+        @test m(PRIMA.SMALL_TR_RADIUS) == SciMLBase.ReturnCode.Success
+        @test m(PRIMA.MAXFUN_REACHED) == SciMLBase.ReturnCode.MaxIters
+        @test m(PRIMA.MAXTR_REACHED) == SciMLBase.ReturnCode.MaxIters
+        @test m(PRIMA.NO_SPACE_BETWEEN_BOUNDS) == SciMLBase.ReturnCode.InitialFailure
+        @test m(PRIMA.ZERO_LINEAR_CONSTRAINT) == SciMLBase.ReturnCode.InitialFailure
+        @test m(PRIMA.INVALID_INPUT) == SciMLBase.ReturnCode.InitialFailure
+        @test m(PRIMA.NAN_INF_X) == SciMLBase.ReturnCode.Unstable
+        @test m(PRIMA.NAN_INF_F) == SciMLBase.ReturnCode.Unstable
+        @test m(PRIMA.NAN_INF_MODEL) == SciMLBase.ReturnCode.Unstable
+        @test m(PRIMA.DAMAGING_ROUNDING) == SciMLBase.ReturnCode.ConvergenceFailure
+        @test m(PRIMA.TRSUBP_FAILED) == SciMLBase.ReturnCode.Failure
+        @test m(PRIMA.ASSERTION_FAILS) == SciMLBase.ReturnCode.Failure
+        @test m(PRIMA.VALIDATION_FAILS) == SciMLBase.ReturnCode.Failure
+        @test m(PRIMA.MEMORY_ALLOCATION_FAILS) == SciMLBase.ReturnCode.Failure
+    end
 
     function prima_con_2c(res, x, p)
         res .= [x[1] + x[2], x[2] * sin(x[1]) - x[1]]


### PR DESCRIPTION
## Summary

Found during the audit done for #1188 / #1187. `OptimizationPRIMA.sciml_prima_retcode` was comparing `PRIMA.reason(inf)` (a human-readable string) against short enum-name tokens like `\"FTARGET_ACHIEVED\"` / `\"MAXFUN_REACHED\"`. Those never matched, so the function's \`if\` branch was dead code. The \`else\` branch had a floating \`rc in [...]\` expression whose return value was discarded, followed by an unconditional \`return ReturnCode.Success\`.

**Net effect: every PRIMA solve reported \`ReturnCode.Success\`** — including NaN/Inf numerics, memory allocation failures, trust-region subproblem failures, and iteration-limit termination.

## What `PRIMA.reason(inf)` actually produces

Verified against the installed PRIMA.jl via \`unsafe_string(prima_get_rc_string(status))\`:

| Status enum | Reason string |
|---|---|
| \`SMALL_TR_RADIUS\` | \`\"Trust region radius reaches its lower bound\"\` |
| \`FTARGET_ACHIEVED\` | \`\"The target function value is reached\"\` |
| \`MAXFUN_REACHED\` | \`\"Maximum number of function evaluations reached\"\` |
| \`MAXTR_REACHED\` | \`\"Maximum number of trust region iterations reached\"\` |
| \`NAN_INF_X\` | \`\"The input X contains NaN of Inf\"\` |
| \`NAN_INF_F\` | \`\"The objective or constraint functions return NaN or +Inf\"\` |
| \`DAMAGING_ROUNDING\` | \`\"Rounding errors are becoming damaging\"\` |
| \`MEMORY_ALLOCATION_FAILS\` | \`\"Memory allocation failed\"\` |
| ... | ... |

None of those match \`\"FTARGET_ACHIEVED\"\` / \`\"MAXFUN_REACHED\"\` / etc.

## Fix

Dispatch on \`inf.status::PRIMA.Status\` directly (mirroring PRIMA's own \`issuccess\` predicate: \`status == SMALL_TR_RADIUS || status == FTARGET_ACHIEVED\`):

| PRIMA.Status | → | SciMLBase.ReturnCode |
|---|---|---|
| \`FTARGET_ACHIEVED\`, \`SMALL_TR_RADIUS\` | → | \`Success\` |
| \`MAXFUN_REACHED\`, \`MAXTR_REACHED\` | → | \`MaxIters\` |
| \`NO_SPACE_BETWEEN_BOUNDS\`, \`ZERO_LINEAR_CONSTRAINT\`, \`INVALID_INPUT\` | → | \`InitialFailure\` |
| \`NAN_INF_X\`, \`NAN_INF_F\`, \`NAN_INF_MODEL\` | → | \`Unstable\` |
| \`DAMAGING_ROUNDING\` | → | \`ConvergenceFailure\` |
| \`TRSUBP_FAILED\`, \`ASSERTION_FAILS\`, \`VALIDATION_FAILS\`, \`MEMORY_ALLOCATION_FAILS\` | → | \`Failure\` |

## Test plan

- [x] Added \`@test sol.retcode == ReturnCode.Success\` assertions to the four existing converged-run tests (UOBYQA/NEWUOA/BOBYQA/LINCOA) — these would have silently passed on the old code even if retcode was wrong, so this just hardens them.
- [x] Added a forced \`maxiters = 3\` run — triggers \`MAXFUN_REACHED\` and asserts \`ReturnCode.MaxIters\`. **This would have falsely returned \`Success\` on the old code.**
- [x] Added an enum-mapping subtestset covering every value of \`PRIMA.Status\` (15 values).
- [x] Full local \`Pkg.test()\` on \`OptimizationPRIMA\`: **29/29 pass** (was 9/9 before).

## Scope

Found during the audit run on #1188. Separate from the Symbol→ReturnCode type fixes there — this one is a semantic correctness bug that was also present on SciMLBase v2 (the old \`Base.convert(::Symbol, ReturnCode.T)\` path never saw these symbols; they took the retcode-helper path that just routed straight to \`Success\`). I verified the other Optimization.jl sublibraries' retcode helpers are correct; this is the only one with this kind of bug.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)