### PR TITLE
Bump 6 subpackages for retcode fixes (#1188, #1189)

### DIFF
--- a/lib/OptimizationCMAEvolutionStrategy/Project.toml
+++ b/lib/OptimizationCMAEvolutionStrategy/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationCMAEvolutionStrategy"
 uuid = "bd407f91-200f-4536-9381-e4ba712f53f8"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.7"
+version = "0.3.8"
 [deps]
 CMAEvolutionStrategy = "8d3b24bd-414e-49e0-94fb-163cc3a3e411"
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"

--- a/lib/OptimizationEvolutionary/Project.toml
+++ b/lib/OptimizationEvolutionary/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationEvolutionary"
 uuid = "cb963754-43f6-435e-8d4b-99009ff27753"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.4.8"
+version = "0.4.9"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 Evolutionary = "86b6b26d-c046-49b6-aa0b-5f0f74682bd6"

--- a/lib/OptimizationGCMAES/Project.toml
+++ b/lib/OptimizationGCMAES/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationGCMAES"
 uuid = "6f0a0517-dbc2-4a7a-8a20-99ae7f27e911"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.7"
+version = "0.3.8"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"

--- a/lib/OptimizationOptimJL/Project.toml
+++ b/lib/OptimizationOptimJL/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationOptimJL"
 uuid = "36348300-93cb-4f02-beb5-3c3902f8871e"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.4.12"
+version = "0.4.13"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/lib/OptimizationPRIMA/Project.toml
+++ b/lib/OptimizationPRIMA/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationPRIMA"
 uuid = "72f8369c-a2ea-4298-9126-56167ce9cbc2"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.7"
+version = "0.3.8"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 PRIMA = "0a7d04aa-8ac2-47b3-b7a7-9dbd6ad661ed"

--- a/lib/OptimizationSpeedMapping/Project.toml
+++ b/lib/OptimizationSpeedMapping/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationSpeedMapping"
 uuid = "3d669222-0d7d-4eb9-8a9f-d8528b0d9b91"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 SpeedMapping = "f1835b91-879b-4a3f-a438-e4baacf14412"


### PR DESCRIPTION
## Summary

Patch-bump six subpackages to register the retcode fixes merged in #1188 and #1189, which landed on master without version bumps.

| Subpackage | Current | New | Fix |
|---|---|---|---|
| OptimizationCMAEvolutionStrategy | 0.3.7 | 0.3.8 | #1188 |
| OptimizationEvolutionary         | 0.4.8 | 0.4.9 | #1188 |
| OptimizationGCMAES               | 0.3.7 | 0.3.8 | #1188 |
| OptimizationOptimJL              | 0.4.12| 0.4.13| #1188 |
| OptimizationSpeedMapping         | 0.2.4 | 0.2.5 | #1188 |
| OptimizationPRIMA                | 0.3.7 | 0.3.8 | #1189 |

- #1188 corrects the `retcode` type to `SciMLBase.ReturnCode.T` across Optim sublibraries.
- #1189 fixes the `OptimizationPRIMA` retcode mapping, which was always returning `Success`.

## Test plan

- [ ] Merge, then register each subpackage via `@JuliaRegistrator register subdir=lib/<subpackage>` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)