### PR TITLE
[AI] OptimizationOptimJL: fix MaxSense+fg, enable allowsfg, fix Zygote ext prep_grad

### DIFF
--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.1.1"
+version = "5.1.2"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]

--- a/lib/OptimizationBase/ext/OptimizationZygoteExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationZygoteExt.jl
@@ -50,7 +50,10 @@ function OptimizationBase.instantiate_function(
     end
 
     if fg == true && f.fg === nothing
-        if g == false
+        # Prepare a gradient prep for fg unless we already have one from the
+        # `g == true && f.grad === nothing` branch above. When the user supplied
+        # `f.grad`, line 37 didn't run, so `prep_grad` was never assigned.
+        if !(g == true && f.grad === nothing)
             prep_grad = prepare_gradient(f.f, adtype, x, Constant(p), strict = Val(false))
         end
         function fg!(res, θ)

--- a/lib/OptimizationOptimJL/Project.toml
+++ b/lib/OptimizationOptimJL/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationOptimJL"
 uuid = "36348300-93cb-4f02-beb5-3c3902f8871e"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.4.13"
+version = "0.4.14"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
+++ b/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
@@ -205,8 +205,8 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: Optim.Abstra
         return cache.sense === OptimizationBase.MaxSense ? -__x : __x
     end
 
-    if cache.f.fg === nothing
-        fg! = function (G, θ)
+    fg! = if cache.f.fg === nothing
+        function (G, θ)
             if G !== nothing
                 cache.f.grad(G, θ)
                 if cache.sense === OptimizationBase.MaxSense
@@ -215,8 +215,14 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: Optim.Abstra
             end
             return _loss(θ)
         end
+    elseif cache.sense === OptimizationBase.MaxSense
+        function (G, θ)
+            y = cache.f.fg(G, θ)
+            G .*= -one(eltype(G))
+            return -y
+        end
     else
-        fg! = cache.f.fg
+        cache.f.fg
     end
 
     if cache.opt isa Optim.KrylovTrustRegion
@@ -320,8 +326,8 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {
         return cache.sense === OptimizationBase.MaxSense ? -__x : __x
     end
 
-    if cache.f.fg === nothing
-        fg! = function (G, θ)
+    fg! = if cache.f.fg === nothing
+        function (G, θ)
             if G !== nothing
                 cache.f.grad(G, θ)
                 if cache.sense === OptimizationBase.MaxSense
@@ -330,8 +336,14 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {
             end
             return _loss(θ)
         end
+    elseif cache.sense === OptimizationBase.MaxSense
+        function (G, θ)
+            y = cache.f.fg(G, θ)
+            G .*= -one(eltype(G))
+            return -y
+        end
     else
-        fg! = cache.f.fg
+        cache.f.fg
     end
 
     gg = function (G, θ)
@@ -401,8 +413,8 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {
         return cache.sense === OptimizationBase.MaxSense ? -__x : __x
     end
 
-    if cache.f.fg === nothing
-        fg! = function (G, θ)
+    fg! = if cache.f.fg === nothing
+        function (G, θ)
             if G !== nothing
                 cache.f.grad(G, θ)
                 if cache.sense === OptimizationBase.MaxSense
@@ -411,8 +423,14 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {
             end
             return _loss(θ)
         end
+    elseif cache.sense === OptimizationBase.MaxSense
+        function (G, θ)
+            y = cache.f.fg(G, θ)
+            G .*= -one(eltype(G))
+            return -y
+        end
     else
-        fg! = cache.f.fg
+        cache.f.fg
     end
 
     gg = function (G, θ)

--- a/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
+++ b/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
@@ -74,7 +74,7 @@ function SciMLBase.requireshessian(
     return true
 end
 SciMLBase.requiresgradient(opt::Optim.Fminbox) = true
-# SciMLBase.allowsfg(opt::Union{Optim.AbstractOptimizer, Optim.ConstrainedOptimizer, Optim.Fminbox, Optim.SAMIN}) = true
+SciMLBase.allowsfg(opt::Union{Optim.AbstractOptimizer, Optim.ConstrainedOptimizer, Optim.Fminbox, Optim.SAMIN}) = true
 
 function __map_optimizer_args(
         cache::OptimizationBase.OptimizationCache,

--- a/lib/OptimizationOptimJL/test/runtests.jl
+++ b/lib/OptimizationOptimJL/test/runtests.jl
@@ -65,6 +65,74 @@ end
         @test isapprox(sol_max.objective, 20.0; atol = 1.0e-2)
     end
 
+    @testset "MaxSense with user-provided fg" begin
+        # Regression test: when the user supplies an `fg` callback and
+        # sense = MaxSense, the OptimJL backend must negate both the value and
+        # the gradient itself, because `supports_sense(::Optim.AbstractOptimizer)
+        # = true` leaves sense handling to the backend (apply_sense is skipped
+        # in the cache).
+
+        # Concave quadratic with maximum at [1.0, 2.0], value 0.
+        obj(x, p) = -((x[1] - 1.0)^2 + (x[2] - 2.0)^2)
+        function grad!(G, x, p)
+            G[1] = -2.0 * (x[1] - 1.0)
+            G[2] = -2.0 * (x[2] - 2.0)
+            return nothing
+        end
+        function fg!(G, x, p)
+            G[1] = -2.0 * (x[1] - 1.0)
+            G[2] = -2.0 * (x[2] - 2.0)
+            return -((x[1] - 1.0)^2 + (x[2] - 2.0)^2)
+        end
+        optf = OptimizationFunction(obj; grad = grad!, fg = fg!)
+
+        # Unconstrained MaxSense (AbstractOptimizer dispatch)
+        prob_max = OptimizationProblem(
+            optf, [5.0, 5.0], nothing; sense = OptimizationBase.MaxSense
+        )
+        sol_max = solve(prob_max, BFGS())
+        @test isapprox(sol_max.u, [1.0, 2.0]; atol = 1.0e-3)
+        @test isapprox(sol_max.objective, 0.0; atol = 1.0e-6)
+
+        # Bounded MaxSense (Fminbox dispatch). Linear objective so the
+        # corner is the maximizer and we can detect a wrong-sign bug.
+        obj_lin(x, p) = x[1] + x[2]
+        function grad_lin!(G, x, p)
+            G[1] = 1.0
+            G[2] = 1.0
+            return nothing
+        end
+        function fg_lin!(G, x, p)
+            G[1] = 1.0
+            G[2] = 1.0
+            return x[1] + x[2]
+        end
+        function hess_lin!(H, x, p)
+            H .= 0.0
+            return nothing
+        end
+        optf_lin = OptimizationFunction(
+            obj_lin; grad = grad_lin!, fg = fg_lin!, hess = hess_lin!
+        )
+
+        prob_max_box = OptimizationProblem(
+            optf_lin, [5.0, 5.0], nothing;
+            lb = [0.0, 0.0], ub = [10.0, 10.0], sense = OptimizationBase.MaxSense
+        )
+        sol_max_box = solve(prob_max_box, BFGS(); x_abstol = 0.1)
+        @test isapprox(sol_max_box.u, [10.0, 10.0]; atol = 1.0e-2)
+        @test isapprox(sol_max_box.objective, 20.0; atol = 1.0e-2)
+
+        # Constrained MaxSense (ConstrainedOptimizer / IPNewton dispatch).
+        prob_max_ipn = OptimizationProblem(
+            optf_lin, [5.0, 5.0], nothing;
+            lb = [0.0, 0.0], ub = [10.0, 10.0], sense = OptimizationBase.MaxSense
+        )
+        sol_max_ipn = solve(prob_max_ipn, Optim.IPNewton(); x_abstol = 0.1)
+        @test isapprox(sol_max_ipn.u, [10.0, 10.0]; atol = 1.0e-2)
+        @test isapprox(sol_max_ipn.objective, 20.0; atol = 1.0e-2)
+    end
+
     rosenbrock(x, p) = (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
     x0 = zeros(2)
     _p = [1.0, 100.0]


### PR DESCRIPTION
## Summary

Three stacked commits making Optim's `fg` codepath correct and active.

1. **`OptimizationOptimJL: apply MaxSense when user supplies fg`** — When `cache.f.fg !== nothing` and `sense === MaxSense`, the three `__solve` dispatches were assigning `fg! = cache.f.fg` raw, without negating the gradient buffer or returned scalar. Optim opts into `supports_sense = true`, so `apply_sense` is skipped in OptimizationBase and the backend must negate itself — the manual fg! branch already did, the user-supplied-fg branch did not. Wraps with negation when MaxSense; adds a regression test covering all three dispatches (6 assertions fail without the fix).

2. **`OptimizationBase: fix Zygote ext UndefVarError when fg requested with user-supplied grad`** — In `OptimizationZygoteExt.instantiate_function`, `prep_grad` is allocated inside either `g == true && f.grad === nothing` or `fg == true && f.fg === nothing && g == false`. When the caller asks for both grad and fg but supplies `f.grad` manually, neither branch runs and the generated `fg!` hits `UndefVarError: prep_grad not defined`. Replaces the `g == false` guard with `!(g == true && f.grad === nothing)`. The DI extension already handles this correctly.

3. **`OptimizationOptimJL: enable allowsfg to share value+gradient pass`** — Flips `SciMLBase.allowsfg = true` for AbstractOptimizer / Fminbox / SAMIN / ConstrainedOptimizer. Optim's first-order line searches evaluate value+gradient at the same trial point, and NLSolversBase routes through `fg!` when supplied; with the flip, OptimizationDIExt / ZygoteExt emit a fused `value_and_gradient!` closure instead of re-evaluating the primal on every trial.

Version bumps: `OptimizationOptimJL 0.4.13 → 0.4.14`, `OptimizationBase 5.1.1 → 5.1.2`.

## Test plan
- [x] `Pkg.test()` for OptimizationOptimJL: 6969 pass
- [x] `Pkg.test()` for OptimizationBase: 739 pass
- [x] Confirmed the new MaxSense+fg testset fails (6 assertions) without commit 1
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)