### PR TITLE
Honor maxiters together with maxtime in OptimizationBBO (fix #1206)

### DIFF
--- a/lib/OptimizationBBO/Project.toml
+++ b/lib/OptimizationBBO/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationBBO"
 uuid = "3e6eede4-6085-4f62-9a71-46d9bc1eb92b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.4.7"
+version = "0.4.8"
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"

--- a/lib/OptimizationBBO/src/OptimizationBBO.jl
+++ b/lib/OptimizationBBO/src/OptimizationBBO.jl
@@ -105,10 +105,18 @@ function map_objective(obj::BlackBoxOptim.IndexedTupleFitness)
 end
 
 function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: BBO}
+    maxiters = OptimizationBase._check_and_convert_maxiters(cache.solver_args.maxiters)
+    maxtime = OptimizationBase._check_and_convert_maxtime(cache.solver_args.maxtime)
+
+    # When `MaxTime` is set, BlackBoxOptim's `check_valid!` clears `MaxSteps` to
+    # zero, so the user's `maxiters` is silently dropped. Enforce it ourselves
+    # from the callback (issue SciML/Optimization.jl#1206).
+    enforce_maxiters = !isnothing(maxiters) && !isnothing(maxtime)
+    has_user_callback = cache.callback !== OptimizationBase.DEFAULT_CALLBACK
+
     function _cb(trace)
-        if cache.callback === OptimizationBase.DEFAULT_CALLBACK
-            cb_call = false
-        else
+        cb_call = false
+        if has_user_callback
             n_steps = BlackBoxOptim.num_steps(trace)
             curr_u = decompose_trace(trace, cache.progress)
             objective = map_objective(BlackBoxOptim.best_fitness(trace))
@@ -120,20 +128,21 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: BBO}
                 original = trace
             )
             cb_call = cache.callback(opt_state, objective)
+            if !(cb_call isa Bool)
+                error("The callback should return a boolean `halt` for whether to stop the optimization process.")
+            end
         end
 
-        if !(cb_call isa Bool)
-            error("The callback should return a boolean `halt` for whether to stop the optimization process.")
+        if enforce_maxiters && BlackBoxOptim.num_steps(trace) >= maxiters
+            cb_call = true
         end
+
         if cb_call == true
-            BlackBoxOptim.shutdown_optimizer!(trace) #doesn't work
+            BlackBoxOptim.shutdown_optimizer!(trace)
         end
 
         return cb_call
     end
-
-    maxiters = OptimizationBase._check_and_convert_maxiters(cache.solver_args.maxiters)
-    maxtime = OptimizationBase._check_and_convert_maxtime(cache.solver_args.maxtime)
 
     _loss = function (θ)
         return cache.f(θ, cache.p)
@@ -141,8 +150,7 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: BBO}
 
     opt_args = __map_optimizer_args(
         cache, cache.opt;
-        callback = cache.callback === OptimizationBase.DEFAULT_CALLBACK ?
-            nothing : _cb,
+        callback = (has_user_callback || enforce_maxiters) ? _cb : nothing,
         cache.solver_args...,
         maxiters = maxiters,
         maxtime = maxtime

--- a/lib/OptimizationBBO/test/runtests.jl
+++ b/lib/OptimizationBBO/test/runtests.jl
@@ -4,6 +4,39 @@ using Test
 using Random
 
 @testset "OptimizationBBO.jl" begin
+    @testset "Issue #1206 maxiters respected when maxtime is set" begin
+        # BlackBoxOptim's `check_valid!` clears `MaxSteps` whenever `MaxTime`
+        # is set, so prior to the fix `maxiters` was silently ignored when
+        # combined with `maxtime`.
+        Random.seed!(1234)
+        rosenbrock(x, p) = (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
+        f = OptimizationFunction(rosenbrock)
+        prob = OptimizationBase.OptimizationProblem(
+            f, zeros(2), [1.0, 100.0], lb = [-1.0, -1.0], ub = [1.0, 1.0]
+        )
+
+        sol_iters = solve(
+            prob, BBO_adaptive_de_rand_1_bin_radiuslimited(); maxiters = 500
+        )
+        @test sol_iters.stats.iterations <= 600
+
+        sol_both = solve(
+            prob, BBO_adaptive_de_rand_1_bin_radiuslimited();
+            maxiters = 500, maxtime = 30
+        )
+        @test sol_both.stats.iterations <= 600
+
+        # `maxiters` still works alongside a user callback.
+        calls = Ref(0)
+        sol_cb = solve(
+            prob, BBO_adaptive_de_rand_1_bin_radiuslimited();
+            maxiters = 300, maxtime = 30,
+            callback = (state, fitness) -> (calls[] += 1; false)
+        )
+        @test sol_cb.stats.iterations <= 400
+        @test calls[] > 0
+    end
+
     @testset "Issue #976 MaxSense regression" begin
         Random.seed!(1234)
         J(x, p) = x[1]


### PR DESCRIPTION
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Fixes #1206. When `maxiters` and `maxtime` were both passed to `solve` with a BBO method, `maxiters` was silently ignored — the optimizer kept running until `maxtime` (or BBO's own convergence heuristic) tripped.

## Root cause

In `BlackBoxOptim.check_valid!` (`default_parameters.jl`):

```julia
elseif params[:MaxTime] > 0.0
    params[:MaxTime] = convert(Float64, params[:MaxTime])
    params[:MaxFuncEvals] = 0
    params[:MaxSteps] = 0    # <-- iteration cap is cleared
end
```

So sending both `MaxSteps` and `MaxTime` to `bbsetup` is ineffective by design — BBO treats `MaxTime` as taking precedence over the step/feval budgets.

## Fix

`OptimizationBBO` already supports installing a `CallbackFunction` on the BBO controller, and `BlackBoxOptim.shutdown_optimizer!(trace)` does in fact stop the run (the old `#doesn't work` comment was stale). When both `maxiters` and `maxtime` are set, install an internal callback that calls `shutdown_optimizer!` once `num_steps(trace) >= maxiters`. The user's own callback (if any) continues to run alongside.

A drive-by: dropped the stale `#doesn't work` comment, since I verified the call does stop the optimizer.

## Reproducer (from the issue)

Before the fix:
```
sol2.stats.iterations  # 12241 — way over maxiters=1000
```

After the fix:
```
sol2.stats.iterations  # 1000
```

## Test plan
- [x] Added `@testset "Issue #1206 maxiters respected when maxtime is set"` covering `maxiters` alone, `maxiters + maxtime`, and `maxiters + maxtime + user callback`.
- [x] Local `Pkg.test()` on `OptimizationBBO` — 29/29 passing.
- [x] `Runic --check` clean on the changed files.