### PR TITLE
Bump OptimizationBase to 5.1.3

### DIFF
--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.1.2"
+version = "5.1.3"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
v5.1.2 was already registered with different tree-sha (likely a prior side-channel registration). Bumping to 5.1.3 so the SciMLLogging compat update from #1198 can be registered.