### PR TITLE
Retain the original OptimizationProblem in OptimizationCache (#1191)

### DIFF
--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.1.3"
+version = "5.2.0"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]

--- a/lib/OptimizationBase/src/cache.jl
+++ b/lib/OptimizationBase/src/cache.jl
@@ -7,7 +7,7 @@ end
 
 struct OptimizationCache{
         O, IIP, F <: SciMLBase.AbstractOptimizationFunction{IIP},
-        RC, LB, UB, LC, UC, S, P, C, M, V,
+        RC, LB, UB, LC, UC, S, P, C, M, V, PR,
     } <:
     SciMLBase.AbstractOptimizationCache
     opt::O
@@ -24,6 +24,13 @@ struct OptimizationCache{
     analysis_results::AnalysisResults
     solver_args::NamedTuple
     verbose::V
+    # Original `OptimizationProblem` the cache was built from. Unlike `f`, which
+    # holds the instantiated objective/constraints with `p` baked into closures,
+    # `prob` keeps the user's untouched problem so the original objective,
+    # constraints, parameters, and bounds remain recoverable from the solution.
+    # Not updated by `reinit!` (which only mutates `reinit_cache`); use
+    # `cache.u0`/`cache.p` for the current state.
+    prob::PR
 end
 
 function OptimizationCache(
@@ -111,7 +118,7 @@ function OptimizationCache(
         prob.ucons, prob.sense,
         progress, callback, manifold, AnalysisResults(obj_res, cons_res),
         merge((; maxiters, maxtime, abstol, reltol), NamedTuple(kwargs)),
-        processed_verbose
+        processed_verbose, prob
     )
 end
 

--- a/lib/OptimizationBase/test/solve_internals_test.jl
+++ b/lib/OptimizationBase/test/solve_internals_test.jl
@@ -187,6 +187,24 @@ function OptimizationBase.__solve(
     )
 end
 
+# Mock solver with has_init = true that also allows constraints, so a constrained
+# problem routes through the real OptimizationCache (not DefaultOptimizationCache).
+struct MockSolverWithInitCons end
+SciMLBase.has_init(::MockSolverWithInitCons) = true
+OptimizationBase.allowsconstraints(::MockSolverWithInitCons) = true
+
+function OptimizationBase.__solve(
+        cache::OptimizationBase.OptimizationCache{MockSolverWithInitCons}
+    )
+    stats = SciMLBase.OptimizationStats(; iterations = 1, time = 0.0, fevals = 1)
+    u = cache.reinit_cache.u0
+    return SciMLBase.build_solution(
+        cache, cache.opt, u, cache.f.f(u, cache.reinit_cache.p);
+        retcode = ReturnCode.Success,
+        stats = stats
+    )
+end
+
 # Mock solver that allows constraints (for _check_opt_alg tests)
 struct MockAlgWithCons end
 OptimizationBase.allowsconstraints(::MockAlgWithCons) = true
@@ -328,4 +346,41 @@ end
     sol = solve_up(prob, nothing, prob.u0, prob.p, alg, :extra_arg)
     @test SciMLBase.successful_retcode(sol)
     @test _mock_ncalls[] == 1
+end
+
+# ============================================================
+# OptimizationCache retains the original OptimizationProblem (issue #1191)
+# ============================================================
+
+@testset "cache retains the original problem" begin
+    objfun = (x, p) -> sum(abs2, x) + sum(p)
+    # Raw, un-instantiated constraint: takes p explicitly and is not p-baked.
+    consfun = (res, x, p) -> (res .= x[1]^2 + x[2]^2)
+    f = OptimizationFunction(objfun, SciMLBase.NoAD(); cons = consfun)
+    p0 = [3.0, 5.0]
+    prob = OptimizationProblem(f, [0.5, 0.5], p0; lcons = [0.0], ucons = [2.0])
+
+    # `init` does not remake the problem, so the cache holds it by identity.
+    cache = init(prob, MockSolverWithInitCons())
+    @test cache.prob === prob
+
+    sol = solve!(cache)
+    # The original problem is recoverable from the solution via the cache.
+    @test sol.cache.prob === prob
+    @test sol.cache.prob.p === p0
+    @test sol.cache.prob.f.f === objfun
+    # The original constraint is the raw user function, not the p-baked closure
+    # that the instantiated cache function carries.
+    @test sol.cache.prob.f.cons === consfun
+    @test sol.cache.f.cons !== consfun
+    @test sol.cache.prob.lcons == [0.0]
+    @test sol.cache.prob.ucons == [2.0]
+
+    # The end-to-end `solve` path remakes the problem, but the stored problem is
+    # still an OptimizationProblem carrying the original objective and parameters.
+    sol2 = solve(prob, MockSolverWithInitCons())
+    @test sol2.cache.prob isa OptimizationProblem
+    @test sol2.cache.prob.f.f === objfun
+    @test sol2.cache.prob.f.cons === consfun
+    @test sol2.cache.prob.p == p0
 end

--- a/lib/OptimizationPRIMA/Project.toml
+++ b/lib/OptimizationPRIMA/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationPRIMA"
 uuid = "72f8369c-a2ea-4298-9126-56167ce9cbc2"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 PRIMA = "0a7d04aa-8ac2-47b3-b7a7-9dbd6ad661ed"
@@ -16,7 +16,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
 julia = "1.10"
-OptimizationBase = "5.1"
+OptimizationBase = "5.2"
 PRIMA = "0.2.0"
 SciMLBase = "2.122.1, 3"
 Reexport = "1"

--- a/lib/OptimizationPRIMA/src/OptimizationPRIMA.jl
+++ b/lib/OptimizationPRIMA/src/OptimizationPRIMA.jl
@@ -65,7 +65,7 @@ function OptimizationBase.OptimizationCache(
         progress, callback, nothing,
         OptimizationBase.OptimizationBase.AnalysisResults(nothing, nothing),
         merge((; maxiters, maxtime, abstol, reltol), NamedTuple(kwargs)),
-        processed_verbose
+        processed_verbose, prob
     )
 end
 


### PR DESCRIPTION
## Summary

Fixes (the Optimization.jl side of) #1191. An `OptimizationSolution` only carries the solved `OptimizationCache` in `sol.cache`. The cache's instantiated `f` bakes the parameters `p` into the objective/constraint closures (see `OptimizationDIExt.jl`, where `cons_oop` closes over `p` in a `let f=f, p=p` block), so the original problem is effectively unrecoverable from a solution. As the reporter notes, that forces a constrained `OptimizationAdjoint` in SciMLSensitivity to dig into those closures to recover the raw constraints/parameters — brittle.

This stores the original, untouched `OptimizationProblem` on the cache as a new `prob` field, so it is recoverable as **`sol.cache.prob`**.

## What changed

- `OptimizationCache` gains a trailing `prob::Pr` field holding the as-constructed problem.
  - Dispatch-safe: every solver's `__solve` dispatches on the leading `OptimizationCache{O}`, and the only two-parameter method (`isinplace`) uses the leading parameters. Appending a trailing type parameter/field disturbs nothing (no `fieldnames`/`ConstructionBase`/`@set`/custom `getproperty` enumerates the layout). `Aqua.test_unbound_args` stays green because the field is typed with the new parameter (`prob::Pr`).
- Both positional inner-constructor call sites pass `prob`: the main keyword constructor (OptimizationBase) and the **duplicated** constructor in OptimizationPRIMA.
- `OptimizationPRIMA` bumps its `OptimizationBase` compat lower bound to `5.2` (its constructor now requires the new field) and bumps its own version.
- `OptimizationBase` `5.1.3 → 5.2.0`.

`reinit!` still only mutates `reinit_cache`; `cache.prob` holds the as-constructed problem (use `cache.u0`/`cache.p` for current state), as documented on the field.

## Companion

A separate SciMLBase PR adds `sol.prob`/`SciMLBase.get_prob(sol)` so the issue's literal `sol.prob` request returns the original problem (it reads `sol.cache.prob`). This PR is independently useful — `sol.cache.prob` works today with it.

## Tests (run locally)

Added a testset in `solve_internals_test.jl` that routes a **constrained** problem through the real `OptimizationCache` and asserts `sol.cache.prob === prob`, that the stored problem exposes the **raw, non-`p`-baked** objective/constraints (`sol.cache.prob.f.cons === consfun`, distinct from `sol.cache.f.cons`), and that `p`/`lcons`/`ucons` are preserved. Verified locally:

- `solve_internals_test.jl` (full file): all testsets pass (incl. new 12-assertion set).
- LBFGSB end-to-end (`init`/`solve!` and `solve`): `sol.cache.prob` is the original problem.
- PRIMA `COBYLA` **constrained** end-to-end: exercises the duplicated PRIMA constructor.
- `Aqua.test_unbound_args(OptimizationBase)`: passes.
- Runic-formatted.

🚧 Draft — please ignore until reviewed by @ChrisRackauckas.
