### PR TITLE
OptimizationMadNLP: support MadNLP 0.10

### DIFF
--- a/lib/OptimizationMadNLP/Project.toml
+++ b/lib/OptimizationMadNLP/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationMadNLP"
 uuid = "5d9c809f-c847-4062-9fba-1793bbfef577"
-version = "2.1.1"
+version = "2.2.0"
 authors = ["Sebastian Micluța-Câmpeanu <sebastian.mc95@proton.me> and contributors"]
 
 [deps]
@@ -17,7 +17,7 @@ SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 DifferentiationInterface = "0.7"
 ForwardDiff = "1.2.1"
 LinearAlgebra = "1.10.0"
-MadNLP = "0.9.1"
+MadNLP = "0.9.1, 0.10"
 ModelingToolkit = "11"
 NLPModels = "0.21.5"
 OptimizationBase = "5.1"


### PR DESCRIPTION
Widens the `MadNLP` compat in OptimizationMadNLP to `"0.9.1, 0.10"` and bumps the package version to `2.2.0`.

MadNLP 0.10 is a SemVer-breaking release, but the breaking surface is internal (allocation removal in `solve!`, type-stability fixes, non-allocating bound counting — #603/#497). Every public symbol OptimizationMadNLP relies on — `MadNLPSolver`, `solve!`, `AbstractUserCallback`/`AbstractMadNLPSolver`, the `Status`/`LogLevels` enums, the barrier and quasi-Newton types, and the KKT/linear-solver types — is unchanged, so no source changes were needed.

Kept `0.9.1` in the range (rather than dropping it) so the downgrade CI keeps exercising the lower bound. The full test suite passes against MadNLP 0.10.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)