### PR TITLE
ci: centralize sublibrary downgrade CI (test all sublibraries)

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -22,12 +22,3 @@ jobs:
       # SymbolicAnalysis skipped: 0.3.x doesn't support Symbolics 7 (required by ModelingToolkit 11)
       skip: "Pkg,TOML,LinearAlgebra,Logging,Printf,Random,SparseArrays,Test,SymbolicAnalysis"
       allow-reresolve: true
-      # Explicit project list preserves the curated set from the bespoke matrix.
-      # Intentionally omitted (genuine downgrade incompatibilities, left for separate floor-bump fixes):
-      #   - lib/OptimizationMetaheuristics: Metaheuristics.jl floor fails to precompile on 1.11
-      #     (UndefVarError: compute_itspace not defined in Base)
-      #   - lib/OptimizationODE: downgraded OrdinaryDiffEq subpackages vs incompatible
-      #     OrdinaryDiffEqCore fail to precompile (get_fsalfirstlast MethodError; namify)
-      #   - lib/OptimizationOptimJL: ModelingToolkit (pulled by its test [targets]) fails to
-      #     precompile under the downgraded deps
-      projects: "lib/OptimizationBBO lib/OptimizationCMAEvolutionStrategy lib/OptimizationEvolutionary lib/OptimizationGCMAES lib/OptimizationMOI lib/OptimizationManopt lib/OptimizationMultistartOptimization lib/OptimizationNLPModels lib/OptimizationNLopt lib/OptimizationNOMAD lib/OptimizationOptimisers lib/OptimizationPRIMA lib/OptimizationPolyalgorithms lib/OptimizationPyCMA lib/OptimizationQuadDIRECT lib/OptimizationSciPy lib/OptimizationSpeedMapping"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

This converts `.github/workflows/DowngradeSublibraries.yml` to the centralized reusable workflow `SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1`. The bespoke matrix is replaced by a one-line caller that preserves the existing `on:` triggers (pull_request/push to master, `docs/**` paths-ignored).

Configuration carried over from the old workflow:
- `julia-version: "1.10"`
- `allow-reresolve: true`
- `skip: Pkg,TOML,LinearAlgebra,Logging,Printf,Random,SparseArrays,Test,SymbolicAnalysis`

No per-sublibrary test group env was set in the old workflow, so none is configured here.

**Now tests ALL `lib/*` sublibraries.** The old workflow used a curated subset of 17 sublibraries (it explicitly commented out `OptimizationMetaheuristics`, `OptimizationODE`, and `OptimizationOptimJL` for known downgrade-floor issues, and never listed several newer ones such as `OptimizationAuglag`, `OptimizationBase`, `OptimizationIpopt`, `OptimizationLBFGSB`, `OptimizationMadNLP`, `OptimizationSophia`, `SimpleOptimization`). By dropping the explicit `projects` list and not setting `exclude`, auto-discovery now covers all 27 `lib/*` packages that have a `Project.toml` (all of which also have `test/runtests.jl`).

⚠️ **These checks are new.** Because previously-excluded/never-listed sublibraries are now included, some may go red:
- `OptimizationMetaheuristics` — old comment: Metaheuristics.jl downgrade floor fails to precompile on 1.11 (`compute_itspace`).
- `OptimizationODE` — old comment: split OrdinaryDiffEq subpackage floors precompile-fail against incompatible OrdinaryDiffEqCore.
- `OptimizationOptimJL` — old comment: MTK test stack fails to precompile under downgraded deps.
- Newly-added sublibraries (`OptimizationAuglag`, `OptimizationBase`, `OptimizationIpopt`, `OptimizationLBFGSB`, `OptimizationMadNLP`, `OptimizationSophia`, `SimpleOptimization`) have no prior downgrade coverage and may surface their own floor issues.

Any genuine floor failures should be fixed with compat lower-bound bumps in the respective sublibrary, not by re-excluding them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)