### PR TITLE
ci: route CI through SciML/.github reusable workflows (@v1)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,158 +10,21 @@ on:
       - master
     paths-ignore:
       - "docs/**"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
 jobs:
   test:
-    runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.group == 'Downstream' }}
+    name: "Tests"
     strategy:
       fail-fast: false
       matrix:
-        group:
-          - Core
-          - OptimizationBase
-          - OptimizationAuglag
-          - OptimizationBBO
-          - OptimizationCMAEvolutionStrategy
-          - OptimizationEvolutionary
-          - OptimizationGCMAES
-          - OptimizationLBFGSB
-          - OptimizationIpopt
-          - OptimizationMadNLP
-          - OptimizationManopt
-          - OptimizationMetaheuristics
-          - OptimizationMOI
-          - OptimizationMultistartOptimization
-          - OptimizationNLopt
-          - OptimizationNOMAD
-          - OptimizationODE
-          - OptimizationOptimJL
-          - OptimizationOptimisers
-          - OptimizationPRIMA
-          - OptimizationPyCMA
-          - OptimizationQuadDIRECT
-          - OptimizationSciPy
-          - OptimizationSophia
-          - OptimizationSpeedMapping
-          - OptimizationPolyalgorithms
-          - OptimizationNLPModels
-          - SimpleOptimization
         version:
           - "1.11"
           - "lts"
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ matrix.version }}-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ matrix.version }}-${{ env.cache-name }}-
-            ${{ runner.os }}-test-${{ matrix.version }}-
-            ${{ runner.os }}-
-      # Serialize precompile workers for the python-using groups. PythonCall's
-      # `JlWrap.__init__` has been observed to fail intermittently with
-      # `UndefRefError: access to undefined reference` when multiple precompile
-      # workers spin up the wrapper-type registration concurrently. Setting
-      # `JULIA_NUM_PRECOMPILE_TASKS=1` removes that race; the cost on these
-      # small subpackages is negligible.
-      - if: ${{ matrix.group == 'OptimizationSciPy' || matrix.group == 'OptimizationPyCMA' }}
-        run: echo "JULIA_NUM_PRECOMPILE_TASKS=1" >> $GITHUB_ENV
-      - uses: julia-actions/julia-buildpkg@v1
-      - if: ${{ matrix.group == 'OptimizationQuadDIRECT' }}
-        run: julia --project -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url  = "https://github.com/HolyLab/HolyLabRegistry.git")); Pkg.add("QuadDIRECT")'
-      - name: ${{ matrix.group }}
-        env:
-          GROUP: ${{ matrix.group }}
-        shell: julia --color=yes --check-bounds=yes --depwarn=yes {0}
-        run: |
-          using Pkg
-          const GROUP = get(ENV, "GROUP", "Core")
-
-          function dev_subpkg(subpkgs::Vector{String})
-            specs = [PackageSpec(path = "lib/$subpkg") for subpkg in subpkgs]
-            Pkg.develop(specs)
-          end
-
-          if GROUP == "Core"
-            Pkg.activate(".")
-          else
-            subpkg_path = "lib/${{ matrix.group }}"
-            Pkg.activate(subpkg_path)
-          end
-
-          if VERSION < v"1.11"
-            @info "Preparing env"
-            if GROUP == "Core"
-              @info "Testing Core"
-              dev_subpkg(["OptimizationBase", "OptimizationLBFGSB", "OptimizationMOI", "OptimizationOptimJL", "OptimizationOptimisers"])
-            elseif GROUP == "OptimizationBase"
-              dev_subpkg(["OptimizationLBFGSB", "OptimizationManopt"])
-            elseif GROUP == "OptimizationAuglag"
-              dev_subpkg(["OptimizationBase", "OptimizationOptimisers"])
-            elseif GROUP == "OptimizationBBO"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationCMAEvolutionStrategy"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationEvolutionary"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationGCMAES"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationLBFGSB"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationIpopt"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationMadNLP"
-              dev_subpkg(["OptimizationBase", "OptimizationNLPModels"])
-            elseif GROUP == "OptimizationManopt"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationMetaheuristics"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationMOI"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationMultistartOptimization"
-              dev_subpkg(["OptimizationBase", "OptimizationNLopt"])
-            elseif GROUP == "OptimizationNLopt"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationNOMAD"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationODE"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationOptimJL"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationOptimisers"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationPRIMA"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationPyCMA"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationQuadDIRECT"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationSciPy"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationSophia"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "OptimizationSpeedMapping"
-              dev_subpkg(["OptimizationBase"])
-            elseif GROUP == "GPU" || GROUP == "OptimizationPolyalgorithms"
-              dev_subpkg(["OptimizationBase", "OptimizationOptimJL", "OptimizationOptimisers"])
-            elseif GROUP == "OptimizationNLPModels"
-              dev_subpkg(["OptimizationBase", "OptimizationMOI", "OptimizationOptimJL", "OptimizationLBFGSB"])
-            elseif GROUP == "SimpleOptimization"
-              dev_subpkg(["OptimizationBase"])
-            end
-          end
-
-          @info "Starting tests"
-          Pkg.test()
-      - uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: src,lib/OptimizationBase/src,lib/OptimizationBBO/src,lib/OptimizationCMAEvolutionStrategy/src,lib/OptimizationEvolutionary/src,lib/OptimizationGCMAES/src,lib/OptimizationIpopt/src,lib/OptimizationMadNLP/src,lib/OptimizationManopt/src,lib/OptimizationMOI/src,lib/OptimizationMetaheuristics/src,lib/OptimizationMultistartOptimization/src,lib/OptimizationNLopt/src,lib/OptimizationNOMAD/src,lib/OptimizationOptimJL/src,lib/OptimizationOptimisers/src,lib/OptimizationPolyalgorithms/src,lib/OptimizationQuadDIRECT/src,lib/OptimizationSpeedMapping/src
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      group: "Core"
+      coverage-directories: "src,lib/OptimizationBase/src,lib/OptimizationBBO/src,lib/OptimizationCMAEvolutionStrategy/src,lib/OptimizationEvolutionary/src,lib/OptimizationGCMAES/src,lib/OptimizationIpopt/src,lib/OptimizationMadNLP/src,lib/OptimizationManopt/src,lib/OptimizationMOI/src,lib/OptimizationMetaheuristics/src,lib/OptimizationMultistartOptimization/src,lib/OptimizationNLopt/src,lib/OptimizationNOMAD/src,lib/OptimizationOptimJL/src,lib/OptimizationOptimisers/src,lib/OptimizationPolyalgorithms/src,lib/OptimizationQuadDIRECT/src,lib/OptimizationSpeedMapping/src"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,24 +12,12 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-        group: ['Core']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          # SymbolicAnalysis skipped: 0.3.x doesn't support Symbolics 7 (required by ModelingToolkit 11)
-          skip: Pkg,TOML,LinearAlgebra,Logging,Printf,Random,SparseArrays,Test,SymbolicAnalysis
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          allow_reresolve: false
-        env:
-          GROUP: ${{ matrix.group }}
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      group: "Core"
+      # SymbolicAnalysis skipped: 0.3.x doesn't support Symbolics 7 (required by ModelingToolkit 11)
+      skip: "Pkg,TOML,LinearAlgebra,Logging,Printf,Random,SparseArrays,Test,SymbolicAnalysis"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -10,63 +10,24 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-        project:
-          - 'lib/OptimizationBBO'
-          - 'lib/OptimizationCMAEvolutionStrategy'
-          - 'lib/OptimizationEvolutionary'
-          - 'lib/OptimizationGCMAES'
-          - 'lib/OptimizationMOI'
-          - 'lib/OptimizationManopt'
-          # OptimizationMetaheuristics disabled: the downgrade resolves Metaheuristics.jl to a
-          # version that fails to precompile on Julia 1.11 (`UndefVarError: compute_itspace not
-          # defined in Base`). Verified in a clean isolated depot — a genuine too-low Metaheuristics
-          # floor, left for a separate floor-bump fix.
-          # - 'lib/OptimizationMetaheuristics'
-          - 'lib/OptimizationMultistartOptimization'
-          - 'lib/OptimizationNLPModels'
-          - 'lib/OptimizationNLopt'
-          - 'lib/OptimizationNOMAD'
-          # OptimizationODE disabled: the downgrade resolves the split OrdinaryDiffEq subpackages
-          # (OrdinaryDiffEqVerner/Rosenbrock/... = 1.0.0) against an incompatible OrdinaryDiffEqCore
-          # 1.36.0, so they fail to precompile (`get_fsalfirstlast` MethodError; `namify` not
-          # importable). Verified in a clean isolated depot — a genuine too-loose lower-bound
-          # combination in OptimizationODE's compat, left for a separate floor-bump fix.
-          # - 'lib/OptimizationODE'
-          # OptimizationOptimJL disabled: resolve+build pass, but the test env (its [targets] test
-          # set pulls in ModelingToolkit) fails: ModelingToolkit does not precompile under the
-          # downgraded deps (errors in ModelingToolkit/src/systems/abstractsystem.jl:2017), so test
-          # setup aborts. Verified in a clean isolated depot, so not parallel-precompile contention;
-          # genuine downgrade incompatibility in the MTK test stack, left for a separate fix.
-          # - 'lib/OptimizationOptimJL'
-          - 'lib/OptimizationOptimisers'
-          - 'lib/OptimizationPRIMA'
-          - 'lib/OptimizationPolyalgorithms'
-          - 'lib/OptimizationPyCMA'
-          - 'lib/OptimizationQuadDIRECT'
-          - 'lib/OptimizationSciPy'
-          - 'lib/OptimizationSpeedMapping'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          projects: ${{ matrix.project }}
-          # SymbolicAnalysis skipped: 0.3.x doesn't support Symbolics 7 (required by ModelingToolkit 11)
-          skip: Pkg,TOML,LinearAlgebra,Logging,Printf,Random,SparseArrays,Test,SymbolicAnalysis
-      - uses: julia-actions/julia-buildpkg@v1
-        with:
-          project: ${{ matrix.project }}
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          project: ${{ matrix.project }}
-          allow_reresolve: true
+  downgrade-sublibraries:
+    uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
+    secrets: "inherit"
+    with:
+      julia-version: "1.10"
+      # SymbolicAnalysis skipped: 0.3.x doesn't support Symbolics 7 (required by ModelingToolkit 11)
+      skip: "Pkg,TOML,LinearAlgebra,Logging,Printf,Random,SparseArrays,Test,SymbolicAnalysis"
+      allow-reresolve: true
+      # Explicit project list preserves the curated set from the bespoke matrix.
+      # Intentionally omitted (genuine downgrade incompatibilities, left for separate floor-bump fixes):
+      #   - lib/OptimizationMetaheuristics: Metaheuristics.jl floor fails to precompile on 1.11
+      #     (UndefVarError: compute_itspace not defined in Base)
+      #   - lib/OptimizationODE: downgraded OrdinaryDiffEq subpackages vs incompatible
+      #     OrdinaryDiffEqCore fail to precompile (get_fsalfirstlast MethodError; namify)
+      #   - lib/OptimizationOptimJL: ModelingToolkit (pulled by its test [targets]) fails to
+      #     precompile under the downgraded deps
+      projects: "lib/OptimizationBBO lib/OptimizationCMAEvolutionStrategy lib/OptimizationEvolutionary lib/OptimizationGCMAES lib/OptimizationMOI lib/OptimizationManopt lib/OptimizationMultistartOptimization lib/OptimizationNLPModels lib/OptimizationNLopt lib/OptimizationNOMAD lib/OptimizationOptimisers lib/OptimizationPRIMA lib/OptimizationPolyalgorithms lib/OptimizationPyCMA lib/OptimizationQuadDIRECT lib/OptimizationSciPy lib/OptimizationSpeedMapping"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,50 +7,18 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
-        os: [ubuntu-latest]
         package:
           - {user: SciML, repo: DiffEqFlux.jl, group: DiffEqFlux}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
           - {user: SciML, repo: ModelingToolkit.jl, group: All}
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          file: lcov.info
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+      julia-version: "1"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,5 +1,4 @@
 name: format-check
-
 on:
   push:
     branches:
@@ -8,15 +7,8 @@ on:
       - 'release-'
     tags: '*'
   pull_request:
-
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SublibraryCI.yml
+++ b/.github/workflows/SublibraryCI.yml
@@ -1,0 +1,19 @@
+name: Sublibrary CI
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - "docs/**"
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - "docs/**"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  sublibrary-ci:
+    uses: "SciML/.github/.github/workflows/sublibrary-tests.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Centralize CI on SciML/.github reusable workflows (@v1)

This routes Optimization.jl's bespoke GitHub Actions workflows through the shared `SciML/.github/.github/workflows/*.yml@v1` reusable workflows, preserving the repo's existing configuration (version/group matrices, downstream packages, downgrade skip lists, coverage directories, triggers, default branch `master`).

### Converted workflows

| File | Was | Now (`@v1` reusable) | Config preserved |
|------|-----|----------------------|------------------|
| `CI.yml` | bespoke combined matrix (Core + 27 sublibrary groups, version 1.11/lts) | `tests.yml@v1` (Core group) | 1.11/lts matrix, `Core` group, full coverage-directories list, `paths-ignore: docs/**`, master triggers |
| `SublibraryCI.yml` | *(new — split out of CI.yml)* | `sublibrary-tests.yml@v1` | auto-discovers `lib/*`; replaces the per-sublibrary groups that the old combined matrix ran |
| `Downgrade.yml` | bespoke (Core, Julia 1.10) | `downgrade.yml@v1` | Julia 1.10, `Core` group, extended skip list (incl. SymbolicAnalysis), `allow-reresolve: false` |
| `DowngradeSublibraries.yml` | bespoke per-project matrix | `sublibrary-downgrade.yml@v1` | curated `projects` list (incl. the intentional Metaheuristics/ODE/OptimJL exclusions), extended skip list, Julia 1.10, `allow-reresolve: true` |
| `Downstream.yml` | bespoke (3 packages) | `downstream.yml@v1` | DiffEqFlux/DiffEqFlux, NeuralPDE/NNPDE, ModelingToolkit/All; Julia 1 |
| `FormatCheck.yml` | bespoke `fredrikekre/runic-action` | `runic.yml@v1` | Runic format check (repo already uses Runic) |
| `SpellCheck.yml` | bespoke `crate-ci/typos` | `spellcheck.yml@v1` | typos spell check |

### Intentionally left bespoke (no faithful reusable mapping — coverage preserved)

- **`Documentation.yml`** — adds the **HolyLabRegistry** and `Pkg.develop`s every `lib/*` subpackage (except OptimizationMultistartOptimization) into the docs environment so `docs/make.jl` can load them. The reusable `documentation.yml@v1` only develops the root package and does not add custom registries, so converting it would break the docs build. Left as-is.
- **`TagBot.yml`** — release automation; no reusable equivalent.
- **`CompatHelper.yml`** — dependency automation with a custom monorepo `subdirs` list; no reusable equivalent.

### Sublibrary (monorepo) handling

The old `CI.yml` was a single combined matrix that tested both `Core` and all 27 `lib/*` sublibraries through a `GROUP` env var. That is split into:
- `CI.yml` → main-package `Core` tests via `tests.yml@v1`.
- `SublibraryCI.yml` → `sublibrary-tests.yml@v1`, which auto-discovers `lib/*` and runs each affected sublibrary's own `test/runtests.jl` using dependency-graph change detection (default groups: Core on lts/1.11/1/pre, QA on 1, since the sublibraries have no `test/test_groups.toml`).
- `DowngradeSublibraries.yml` → `sublibrary-downgrade.yml@v1`, carrying over the curated project list, the extended skip list, Julia 1.10 and `allow-reresolve: true`.

### NOTE — required-status-check names change

The job names produced by the reusable workflows differ from the old bespoke job names (e.g. `Tests - Core`, `Downgrade Tests - Core`, `Downstream Tests - <group>`, `Runic Format Check`, `Spell Check with Typos`, plus a dynamic sublibrary matrix). **Branch protection required-status-check names must be updated** to match the new job names, or merges will block on checks that no longer report.

---

Please ignore until reviewed by @ChrisRackauckas.