### PR TITLE
Drop now-invalid allow-reresolve input from downgrade workflow(s)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -19,5 +19,4 @@ jobs:
       group: "Core"
       # SymbolicAnalysis skipped: 0.3.x doesn't support Symbolics 7 (required by ModelingToolkit 11)
       skip: "Pkg,TOML,LinearAlgebra,Logging,Printf,Random,SparseArrays,Test,SymbolicAnalysis"
-      allow-reresolve: false
     secrets: "inherit"

--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -21,4 +21,3 @@ jobs:
       julia-version: "1.10"
       # SymbolicAnalysis skipped: 0.3.x doesn't support Symbolics 7 (required by ModelingToolkit 11)
       skip: "Pkg,TOML,LinearAlgebra,Logging,Printf,Random,SparseArrays,Test,SymbolicAnalysis"
-      allow-reresolve: true


### PR DESCRIPTION
## What

Remove the now-invalid `allow-reresolve:` input from the downgrade workflow(s).

The centralized `SciML/.github` downgrade workflows (`downgrade.yml` and
`sublibrary-downgrade.yml`) are being changed to **always** use
`allow_reresolve: false` and to drop the `allow-reresolve` `workflow_call`
input entirely (see SciML/.github#71). Once that merges and `@v1` is retagged,
any caller still passing `allow-reresolve:` would fail with an invalid-input
error. This PR removes that line so this repo keeps working.
**Behavior note:** this repo passed `allow-reresolve: true` in one or more
downgrade files, so removing it makes the downgrade run strict
(`allow_reresolve: false`). That is the intended policy outcome, but it is a
real behavior change and may surface previously-hidden compat-floor conflicts.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>