### PR TITLE
Simplify root CI to grouped-tests.yml (matrix from test/test_groups.toml)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,25 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
 jobs:
-  test:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - "Core"
-        version:
-          - "lts"
-          - "1"
-          - "pre"
-        include:
-          - group: "QA"
-            version: "lts"
-          - group: "QA"
-            version: "1"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+  tests:
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
       coverage-directories: "src,lib/OptimizationBase/src,lib/OptimizationBBO/src,lib/OptimizationCMAEvolutionStrategy/src,lib/OptimizationEvolutionary/src,lib/OptimizationGCMAES/src,lib/OptimizationIpopt/src,lib/OptimizationMadNLP/src,lib/OptimizationManopt/src,lib/OptimizationMOI/src,lib/OptimizationMetaheuristics/src,lib/OptimizationMultistartOptimization/src,lib/OptimizationNLopt/src,lib/OptimizationNOMAD/src,lib/OptimizationOptimJL/src,lib/OptimizationOptimisers/src,lib/OptimizationPolyalgorithms/src,lib/OptimizationQuadDIRECT/src,lib/OptimizationSpeedMapping/src"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -3,7 +3,3 @@ versions = ["lts", "1", "pre"]
 
 [QA]
 versions = ["lts", "1"]
-
-[GPU]
-versions = ["1"]
-runner = ["self-hosted", "Linux", "X64", "gpu"]


### PR DESCRIPTION
## What

Replaces the hand-maintained `group × version` matrix in the **root** `.github/workflows/CI.yml` test job with the thin `grouped-tests.yml@v1` caller. The matrix now lives in the root `test/test_groups.toml` and is computed by `compute_affected_sublibraries.jl --root-matrix`.

```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    with:
      coverage-directories: "src,lib/OptimizationBase/src,..."
    secrets: "inherit"
```

- `name: CI` and the filename are unchanged, so the branch-protection status-check name is preserved.
- `on:` triggers and `concurrency:` are kept verbatim.
- `coverage-directories` is preserved as the only non-default `with:` input.
- Group dispatch stays on the default `GROUP` env var, which the root `test/runtests.jl` reads (`get(ENV, "GROUP", "Core")`). `coverage` (true) and `check-bounds` (`yes`) keep their defaults, matching the old root `tests.yml@v1` call.
- The `SublibraryCI.yml` workflow (which calls `sublibrary-project-tests.yml@v1`) and the `IntegrationTest`/`Downstream.yml` workflow are untouched.

## test/test_groups.toml

Trimmed to exactly the groups the root CI workflow actually ran:

```toml
[Core]
versions = ["lts", "1", "pre"]

[QA]
versions = ["lts", "1"]
```

The `GPU` group that the monorepo uniformization (#1220) added to this file speculatively is dropped: the root `CI.yml` never dispatched a GPU job (there was no self-hosted GPU runner cell), so keeping it would invent a matrix entry that did not run before and would attempt to schedule on a self-hosted GPU runner.

## Verified matrix match (5/5 exact)

`julia compute_affected_sublibraries.jl <repo> --root-matrix` yields exactly the old workflow's set:

| group | versions |
|-------|----------|
| Core  | lts, 1, pre |
| QA    | lts, 1 |

`{(Core,lts),(Core,1),(Core,pre),(QA,lts),(QA,1)}` — no missing, no extra. TOML and YAML both parse cleanly. Package test suite not run locally (heavy; CI validates).

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)