### PR TITLE
Add QA (Aqua/JET) groups to sublibraries (SciML/.github#77)

### DIFF
--- a/lib/OptimizationAuglag/Project.toml
+++ b/lib/OptimizationAuglag/Project.toml
@@ -10,6 +10,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
@@ -22,6 +23,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 OptimizationOptimisers = {path = "../OptimizationOptimisers"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 ForwardDiff = "1.0.1"
 LinearAlgebra = "1.10"
@@ -34,4 +36,4 @@ Test = "1.10.0"
 julia = "1.10"
 
 [targets]
-test = ["Test", "ForwardDiff", "MLUtils", "OptimizationOptimisers", "Random", "SafeTestsets"]
+test = ["Test", "ForwardDiff", "MLUtils", "OptimizationOptimisers", "Random", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationAuglag/test/qa/Project.toml
+++ b/lib/OptimizationAuglag/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationAuglag = "2ea93f80-9333-43a1-a68d-1f53b957a421"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationAuglag = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationAuglag = "2"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationAuglag/test/qa/qa.jl
+++ b/lib/OptimizationAuglag/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationAuglag, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationAuglag)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationAuglag; target_defined_modules = true)
+end

--- a/lib/OptimizationAuglag/test/runtests.jl
+++ b/lib/OptimizationAuglag/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationAuglag/test/test_groups.toml
+++ b/lib/OptimizationAuglag/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationBBO/Project.toml
+++ b/lib/OptimizationBBO/Project.toml
@@ -9,6 +9,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -17,6 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 BlackBoxOptim = "0.6.3"
@@ -25,4 +27,4 @@ SciMLBase = "2.122.1, 3"
 Reexport = "1.2"
 
 [targets]
-test = ["Random", "Test", "SafeTestsets"]
+test = ["Random", "Test", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationBBO/test/qa/Project.toml
+++ b/lib/OptimizationBBO/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationBBO = "3e6eede4-6085-4f62-9a71-46d9bc1eb92b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationBBO = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationBBO = "0.4"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationBBO/test/qa/qa.jl
+++ b/lib/OptimizationBBO/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationBBO, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationBBO)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationBBO; target_defined_modules = true)
+end

--- a/lib/OptimizationBBO/test/runtests.jl
+++ b/lib/OptimizationBBO/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationBBO/test/test_groups.toml
+++ b/lib/OptimizationBBO/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationBase/test/qa/Project.toml
+++ b/lib/OptimizationBase/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationBase = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationBase = "5"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationBase/test/qa/qa.jl
+++ b/lib/OptimizationBase/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationBase, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationBase)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationBase; target_defined_modules = true)
+end

--- a/lib/OptimizationBase/test/runtests.jl
+++ b/lib/OptimizationBase/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationBase/test/test_groups.toml
+++ b/lib/OptimizationBase/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationCMAEvolutionStrategy/Project.toml
+++ b/lib/OptimizationCMAEvolutionStrategy/Project.toml
@@ -9,6 +9,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -16,6 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 CMAEvolutionStrategy = "0.2"
 julia = "1.10"
@@ -24,4 +26,4 @@ SciMLBase = "2.122.1, 3"
 Reexport = "1.2"
 
 [targets]
-test = ["Test", "SafeTestsets"]
+test = ["Test", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationCMAEvolutionStrategy/test/qa/Project.toml
+++ b/lib/OptimizationCMAEvolutionStrategy/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationCMAEvolutionStrategy = "bd407f91-200f-4536-9381-e4ba712f53f8"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationCMAEvolutionStrategy = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationCMAEvolutionStrategy = "0.3"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationCMAEvolutionStrategy/test/qa/qa.jl
+++ b/lib/OptimizationCMAEvolutionStrategy/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationCMAEvolutionStrategy, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationCMAEvolutionStrategy)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationCMAEvolutionStrategy; target_defined_modules = true)
+end

--- a/lib/OptimizationCMAEvolutionStrategy/test/runtests.jl
+++ b/lib/OptimizationCMAEvolutionStrategy/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationCMAEvolutionStrategy/test/test_groups.toml
+++ b/lib/OptimizationCMAEvolutionStrategy/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationEvolutionary/Project.toml
+++ b/lib/OptimizationEvolutionary/Project.toml
@@ -9,6 +9,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -17,6 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5"
@@ -25,4 +27,4 @@ SciMLBase = "2.122.1, 3"
 Reexport = "1.2"
 
 [targets]
-test = ["Random", "Test", "SafeTestsets"]
+test = ["Random", "Test", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationEvolutionary/test/qa/Project.toml
+++ b/lib/OptimizationEvolutionary/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationEvolutionary = "cb963754-43f6-435e-8d4b-99009ff27753"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationEvolutionary = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationEvolutionary = "0.4"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationEvolutionary/test/qa/qa.jl
+++ b/lib/OptimizationEvolutionary/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationEvolutionary, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationEvolutionary)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationEvolutionary; target_defined_modules = true)
+end

--- a/lib/OptimizationEvolutionary/test/runtests.jl
+++ b/lib/OptimizationEvolutionary/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationEvolutionary/test/test_groups.toml
+++ b/lib/OptimizationEvolutionary/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationGCMAES/Project.toml
+++ b/lib/OptimizationGCMAES/Project.toml
@@ -9,6 +9,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 GCMAES = "4aa9d100-eb0f-11e8-15f1-25748831eb3b"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -17,6 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5.1"
@@ -25,4 +27,4 @@ Reexport = "1.2"
 GCMAES = "0.1.34"
 
 [targets]
-test = ["ForwardDiff", "Test", "SafeTestsets"]
+test = ["ForwardDiff", "Test", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationGCMAES/test/qa/Project.toml
+++ b/lib/OptimizationGCMAES/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationGCMAES = "6f0a0517-dbc2-4a7a-8a20-99ae7f27e911"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationGCMAES = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationGCMAES = "0.3"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationGCMAES/test/qa/qa.jl
+++ b/lib/OptimizationGCMAES/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationGCMAES, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationGCMAES)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationGCMAES; target_defined_modules = true)
+end

--- a/lib/OptimizationGCMAES/test/runtests.jl
+++ b/lib/OptimizationGCMAES/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationGCMAES/test/test_groups.toml
+++ b/lib/OptimizationGCMAES/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationIpopt/Project.toml
+++ b/lib/OptimizationIpopt/Project.toml
@@ -12,6 +12,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 Ipopt = "1.10.3"
 LinearAlgebra = "1.10.0"
@@ -28,6 +29,7 @@ julia = "1.10"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
@@ -38,4 +40,4 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "ModelingToolkit", "Random", "ReverseDiff", "Test", "Symbolics", "Zygote", "SafeTestsets"]
+test = ["Aqua", "ModelingToolkit", "Random", "ReverseDiff", "Test", "Symbolics", "Zygote", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationIpopt/test/qa/Project.toml
+++ b/lib/OptimizationIpopt/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationIpopt = "43fad042-7963-4b32-ab19-e2a4f9a67124"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationIpopt = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationIpopt = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationIpopt/test/qa/qa.jl
+++ b/lib/OptimizationIpopt/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationIpopt, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationIpopt)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationIpopt; target_defined_modules = true)
+end

--- a/lib/OptimizationIpopt/test/runtests.jl
+++ b/lib/OptimizationIpopt/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationIpopt/test/test_groups.toml
+++ b/lib/OptimizationIpopt/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationLBFGSB/Project.toml
+++ b/lib/OptimizationLBFGSB/Project.toml
@@ -10,6 +10,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
@@ -20,6 +21,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 DocStringExtensions = "0.9.5"
 ForwardDiff = "1.0.1"
@@ -32,4 +34,4 @@ Zygote = "0.7.10"
 julia = "1.10"
 
 [targets]
-test = ["Test", "ForwardDiff", "MLUtils", "Zygote", "SafeTestsets"]
+test = ["Test", "ForwardDiff", "MLUtils", "Zygote", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationLBFGSB/test/qa/Project.toml
+++ b/lib/OptimizationLBFGSB/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationLBFGSB = "22f7324a-a79d-40f2-bebe-3af60c77bd15"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationLBFGSB = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationLBFGSB = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationLBFGSB/test/qa/qa.jl
+++ b/lib/OptimizationLBFGSB/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationLBFGSB, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationLBFGSB)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationLBFGSB; target_defined_modules = true)
+end

--- a/lib/OptimizationLBFGSB/test/runtests.jl
+++ b/lib/OptimizationLBFGSB/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationLBFGSB/test/test_groups.toml
+++ b/lib/OptimizationLBFGSB/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationMOI/Project.toml
+++ b/lib/OptimizationMOI/Project.toml
@@ -23,6 +23,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 AmplNLWriter = "1"
 HiGHS = "1"
@@ -47,6 +48,7 @@ Zygote = "0.6, 0.7"
 julia = "1.10"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 AmplNLWriter = "7c4d4715-977e-5154-bfe0-e096adeac482"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
@@ -59,4 +61,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["AmplNLWriter", "HiGHS", "Ipopt", "Ipopt_jll", "Juniper", "NLopt", "ReverseDiff", "Test", "Zygote", "SafeTestsets"]
+test = ["AmplNLWriter", "HiGHS", "Ipopt", "Ipopt_jll", "Juniper", "NLopt", "ReverseDiff", "Test", "Zygote", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationMOI/test/qa/Project.toml
+++ b/lib/OptimizationMOI/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationMOI = "fd9f6733-72f4-499f-8506-86b2bdd0dea1"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationMOI = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationMOI = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationMOI/test/qa/qa.jl
+++ b/lib/OptimizationMOI/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationMOI, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationMOI)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationMOI; target_defined_modules = true)
+end

--- a/lib/OptimizationMOI/test/runtests.jl
+++ b/lib/OptimizationMOI/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationMOI/test/test_groups.toml
+++ b/lib/OptimizationMOI/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationMadNLP/Project.toml
+++ b/lib/OptimizationMadNLP/Project.toml
@@ -14,6 +14,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 DifferentiationInterface = "0.7"
 ForwardDiff = "1.2.1"
@@ -34,6 +35,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 OptimizationNLPModels = {path = "../OptimizationNLPModels"}
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -48,4 +50,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ADTypes", "Aqua", "DifferentiationInterface", "ForwardDiff", "ModelingToolkit", "Random", "ReverseDiff", "Test", "SparseArrays", "Symbolics", "Zygote", "SafeTestsets"]
+test = ["ADTypes", "Aqua", "DifferentiationInterface", "ForwardDiff", "ModelingToolkit", "Random", "ReverseDiff", "Test", "SparseArrays", "Symbolics", "Zygote", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationMadNLP/test/qa/Project.toml
+++ b/lib/OptimizationMadNLP/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationMadNLP = "5d9c809f-c847-4062-9fba-1793bbfef577"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationMadNLP = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationMadNLP = "2"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationMadNLP/test/qa/qa.jl
+++ b/lib/OptimizationMadNLP/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationMadNLP, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationMadNLP)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationMadNLP; target_defined_modules = true)
+end

--- a/lib/OptimizationMadNLP/test/runtests.jl
+++ b/lib/OptimizationMadNLP/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationMadNLP/test/test_groups.toml
+++ b/lib/OptimizationMadNLP/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationManopt/Project.toml
+++ b/lib/OptimizationManopt/Project.toml
@@ -13,6 +13,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -29,6 +30,7 @@ Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 DifferentiationInterface = "0.7"
@@ -42,4 +44,4 @@ Reexport = "1.2"
 SciMLBase = "2.122.1, 3"
 
 [targets]
-test = ["DifferentiationInterface", "Enzyme", "ForwardDiff", "FiniteDiff", "QuadraticModels", "Random", "ReverseDiff", "RipQP", "Test", "Zygote", "SafeTestsets"]
+test = ["DifferentiationInterface", "Enzyme", "ForwardDiff", "FiniteDiff", "QuadraticModels", "Random", "ReverseDiff", "RipQP", "Test", "Zygote", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationManopt/test/qa/Project.toml
+++ b/lib/OptimizationManopt/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationManopt = "e57b7fff-7ee7-4550-b4f0-90e9476e9fb6"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationManopt = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationManopt = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationManopt/test/qa/qa.jl
+++ b/lib/OptimizationManopt/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationManopt, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationManopt)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationManopt; target_defined_modules = true)
+end

--- a/lib/OptimizationManopt/test/runtests.jl
+++ b/lib/OptimizationManopt/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationManopt/test/test_groups.toml
+++ b/lib/OptimizationManopt/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationMetaheuristics/Project.toml
+++ b/lib/OptimizationMetaheuristics/Project.toml
@@ -9,6 +9,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -17,6 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5"
@@ -25,4 +27,4 @@ SciMLBase = "2.122.1, 3"
 Reexport = "1.2"
 
 [targets]
-test = ["Random", "Test", "SafeTestsets"]
+test = ["Random", "Test", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationMetaheuristics/test/qa/Project.toml
+++ b/lib/OptimizationMetaheuristics/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationMetaheuristics = "3aafef2f-86ae-4776-b337-85a36adf0b55"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationMetaheuristics = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationMetaheuristics = "0.3"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationMetaheuristics/test/qa/qa.jl
+++ b/lib/OptimizationMetaheuristics/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationMetaheuristics, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationMetaheuristics)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationMetaheuristics; target_defined_modules = true)
+end

--- a/lib/OptimizationMetaheuristics/test/runtests.jl
+++ b/lib/OptimizationMetaheuristics/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationMetaheuristics/test/test_groups.toml
+++ b/lib/OptimizationMetaheuristics/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationMultistartOptimization/Project.toml
+++ b/lib/OptimizationMultistartOptimization/Project.toml
@@ -21,6 +21,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 OptimizationNLopt = {path = "../OptimizationNLopt"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5"

--- a/lib/OptimizationMultistartOptimization/test/qa/Project.toml
+++ b/lib/OptimizationMultistartOptimization/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationMultistartOptimization = "e4316d97-8bbb-4fd3-a7d8-3851d2a72823"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationMultistartOptimization = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationMultistartOptimization = "0.3"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationMultistartOptimization/test/qa/qa.jl
+++ b/lib/OptimizationMultistartOptimization/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationMultistartOptimization, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationMultistartOptimization)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationMultistartOptimization; target_defined_modules = true)
+end

--- a/lib/OptimizationMultistartOptimization/test/runtests.jl
+++ b/lib/OptimizationMultistartOptimization/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationMultistartOptimization/test/test_groups.toml
+++ b/lib/OptimizationMultistartOptimization/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationNLPModels/Project.toml
+++ b/lib/OptimizationNLPModels/Project.toml
@@ -18,6 +18,7 @@ OptimizationMOI = {path = "../OptimizationMOI"}
 OptimizationOptimJL = {path = "../OptimizationOptimJL"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 ADTypes = "1.18"
 NLPModels = "0.21"
@@ -28,6 +29,7 @@ SparseArrays = "1.10.0"
 julia = "1.10"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 NLPModelsTest = "7998695d-6960-4d3a-85c4-e1bceb8cd856"
@@ -39,4 +41,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "NLPModelsTest", "OptimizationOptimJL", "ReverseDiff", "Zygote", "Ipopt", "OptimizationMOI", "OptimizationLBFGSB", "SafeTestsets"]
+test = ["Test", "NLPModelsTest", "OptimizationOptimJL", "ReverseDiff", "Zygote", "Ipopt", "OptimizationMOI", "OptimizationLBFGSB", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationNLPModels/test/qa/Project.toml
+++ b/lib/OptimizationNLPModels/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationNLPModels = "064b21be-54cf-11ef-1646-cdfee32b588f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationNLPModels = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationNLPModels = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationNLPModels/test/qa/qa.jl
+++ b/lib/OptimizationNLPModels/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationNLPModels, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationNLPModels)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationNLPModels; target_defined_modules = true)
+end

--- a/lib/OptimizationNLPModels/test/runtests.jl
+++ b/lib/OptimizationNLPModels/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationNLPModels/test/test_groups.toml
+++ b/lib/OptimizationNLPModels/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationNLopt/Project.toml
+++ b/lib/OptimizationNLopt/Project.toml
@@ -11,6 +11,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
@@ -20,6 +21,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5.1"
@@ -28,4 +30,4 @@ SciMLBase = "2.122.1, 3"
 Reexport = "1.2"
 
 [targets]
-test = ["ReverseDiff", "Test", "Zygote", "SafeTestsets"]
+test = ["ReverseDiff", "Test", "Zygote", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationNLopt/test/qa/Project.toml
+++ b/lib/OptimizationNLopt/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationNLopt = "4e6fcdb7-1186-4e1f-a706-475e75c168bb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationNLopt = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationNLopt = "0.3"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationNLopt/test/qa/qa.jl
+++ b/lib/OptimizationNLopt/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationNLopt, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationNLopt)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationNLopt; target_defined_modules = true)
+end

--- a/lib/OptimizationNLopt/test/runtests.jl
+++ b/lib/OptimizationNLopt/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationNLopt/test/test_groups.toml
+++ b/lib/OptimizationNLopt/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationNOMAD/Project.toml
+++ b/lib/OptimizationNOMAD/Project.toml
@@ -9,6 +9,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -16,6 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5"
@@ -24,4 +26,4 @@ SciMLBase = "2.58, 3"
 Reexport = "1.2"
 
 [targets]
-test = ["Test", "SafeTestsets"]
+test = ["Test", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationNOMAD/test/qa/Project.toml
+++ b/lib/OptimizationNOMAD/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationNOMAD = "2cab0595-8222-4775-b714-9828e6a9e01b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationNOMAD = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationNOMAD = "0.3"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationNOMAD/test/qa/qa.jl
+++ b/lib/OptimizationNOMAD/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationNOMAD, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationNOMAD)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationNOMAD; target_defined_modules = true)
+end

--- a/lib/OptimizationNOMAD/test/runtests.jl
+++ b/lib/OptimizationNOMAD/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationNOMAD/test/test_groups.toml
+++ b/lib/OptimizationNOMAD/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationODE/Project.toml
+++ b/lib/OptimizationODE/Project.toml
@@ -20,6 +20,7 @@ SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 ADTypes = "1.18"
 DiffEqBase = "6.190.2, 7"
@@ -41,9 +42,10 @@ julia = "1.10"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Sundials", "Test", "SafeTestsets"]
+test = ["Sundials", "Test", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationODE/test/qa/Project.toml
+++ b/lib/OptimizationODE/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationODE = "dfa73e59-e644-4d8a-bf84-188d7ecb34e4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationODE = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationODE = "0.1"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationODE/test/qa/qa.jl
+++ b/lib/OptimizationODE/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationODE, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationODE)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationODE; target_defined_modules = true)
+end

--- a/lib/OptimizationODE/test/runtests.jl
+++ b/lib/OptimizationODE/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationODE/test/test_groups.toml
+++ b/lib/OptimizationODE/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationOptimJL/Project.toml
+++ b/lib/OptimizationOptimJL/Project.toml
@@ -10,6 +10,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
@@ -19,6 +20,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5.1"
@@ -31,4 +33,4 @@ SciMLBase = "2.122.1, 3"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [targets]
-test = ["ForwardDiff", "ModelingToolkit", "Random", "ReverseDiff", "Test", "Zygote", "SafeTestsets"]
+test = ["ForwardDiff", "ModelingToolkit", "Random", "ReverseDiff", "Test", "Zygote", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationOptimJL/test/qa/Project.toml
+++ b/lib/OptimizationOptimJL/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationOptimJL = "36348300-93cb-4f02-beb5-3c3902f8871e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationOptimJL = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationOptimJL = "0.4"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationOptimJL/test/qa/qa.jl
+++ b/lib/OptimizationOptimJL/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationOptimJL, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationOptimJL)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationOptimJL; target_defined_modules = true)
+end

--- a/lib/OptimizationOptimJL/test/runtests.jl
+++ b/lib/OptimizationOptimJL/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationOptimJL/test/test_groups.toml
+++ b/lib/OptimizationOptimJL/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationOptimisers/Project.toml
+++ b/lib/OptimizationOptimisers/Project.toml
@@ -14,6 +14,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 Logging = "1.10"
 Optimisers = "0.4.2"
@@ -23,6 +24,7 @@ SciMLBase = "2.122.1, 3"
 julia = "1.10"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -35,4 +37,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ComponentArrays", "ForwardDiff", "Lux", "MLDataDevices", "MLUtils", "Random", "Test", "Zygote", "Printf", "SafeTestsets"]
+test = ["ComponentArrays", "ForwardDiff", "Lux", "MLDataDevices", "MLUtils", "Random", "Test", "Zygote", "Printf", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationOptimisers/test/qa/Project.toml
+++ b/lib/OptimizationOptimisers/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationOptimisers = "42dfb2eb-d2b4-4451-abcd-913932933ac1"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationOptimisers = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationOptimisers = "0.3"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationOptimisers/test/qa/qa.jl
+++ b/lib/OptimizationOptimisers/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationOptimisers, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationOptimisers)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationOptimisers; target_defined_modules = true)
+end

--- a/lib/OptimizationOptimisers/test/runtests.jl
+++ b/lib/OptimizationOptimisers/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationOptimisers/test/test_groups.toml
+++ b/lib/OptimizationOptimisers/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationPRIMA/Project.toml
+++ b/lib/OptimizationPRIMA/Project.toml
@@ -9,6 +9,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
@@ -16,6 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5.1"
@@ -27,4 +29,4 @@ Reexport = "1"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [targets]
-test = ["Test", "ForwardDiff", "ModelingToolkit", "ReverseDiff", "SafeTestsets"]
+test = ["Test", "ForwardDiff", "ModelingToolkit", "ReverseDiff", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationPRIMA/test/qa/Project.toml
+++ b/lib/OptimizationPRIMA/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationPRIMA = "72f8369c-a2ea-4298-9126-56167ce9cbc2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationPRIMA = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationPRIMA = "0.3"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationPRIMA/test/qa/qa.jl
+++ b/lib/OptimizationPRIMA/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationPRIMA, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationPRIMA)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationPRIMA; target_defined_modules = true)
+end

--- a/lib/OptimizationPRIMA/test/runtests.jl
+++ b/lib/OptimizationPRIMA/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationPRIMA/test/test_groups.toml
+++ b/lib/OptimizationPRIMA/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationPolyalgorithms/Project.toml
+++ b/lib/OptimizationPolyalgorithms/Project.toml
@@ -10,6 +10,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 OptimizationOptimJL = "36348300-93cb-4f02-beb5-3c3902f8871e"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -20,6 +21,7 @@ OptimizationOptimisers = {path = "../OptimizationOptimisers"}
 OptimizationOptimJL = {path = "../OptimizationOptimJL"}
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5"
@@ -29,4 +31,4 @@ Reexport = "1.2"
 OptimizationOptimJL = "0.4.10"
 
 [targets]
-test = ["ForwardDiff", "Test", "SafeTestsets"]
+test = ["ForwardDiff", "Test", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationPolyalgorithms/test/qa/Project.toml
+++ b/lib/OptimizationPolyalgorithms/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationPolyalgorithms = "500b13db-7e66-49ce-bda4-eed966be6282"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationPolyalgorithms = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationPolyalgorithms = "0.3"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationPolyalgorithms/test/qa/qa.jl
+++ b/lib/OptimizationPolyalgorithms/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationPolyalgorithms, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationPolyalgorithms)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationPolyalgorithms; target_defined_modules = true)
+end

--- a/lib/OptimizationPolyalgorithms/test/runtests.jl
+++ b/lib/OptimizationPolyalgorithms/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationPolyalgorithms/test/test_groups.toml
+++ b/lib/OptimizationPolyalgorithms/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationPyCMA/Project.toml
+++ b/lib/OptimizationPyCMA/Project.toml
@@ -11,6 +11,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [compat]
+Pkg = "1"
 julia = "1.10"
 OptimizationBase = "5"
 CondaPkg = "0.2"
@@ -24,7 +25,8 @@ PythonCall = "0.9"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [targets]
-test = ["SafeTestsets"]
+test = ["SafeTestsets", "Pkg"]

--- a/lib/OptimizationPyCMA/test/qa/Project.toml
+++ b/lib/OptimizationPyCMA/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationPyCMA = "fb0822aa-1fe5-41d8-99a6-e7bf6c238d3b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationPyCMA = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationPyCMA = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationPyCMA/test/qa/qa.jl
+++ b/lib/OptimizationPyCMA/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationPyCMA, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationPyCMA)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationPyCMA; target_defined_modules = true)
+end

--- a/lib/OptimizationPyCMA/test/runtests.jl
+++ b/lib/OptimizationPyCMA/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationPyCMA/test/test_groups.toml
+++ b/lib/OptimizationPyCMA/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationQuadDIRECT/Project.toml
+++ b/lib/OptimizationQuadDIRECT/Project.toml
@@ -14,6 +14,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5"

--- a/lib/OptimizationQuadDIRECT/test/qa/Project.toml
+++ b/lib/OptimizationQuadDIRECT/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationQuadDIRECT = "842ac81e-713d-465f-80f7-84eddaced298"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationQuadDIRECT = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationQuadDIRECT = "0.3"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationQuadDIRECT/test/qa/qa.jl
+++ b/lib/OptimizationQuadDIRECT/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationQuadDIRECT, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationQuadDIRECT)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationQuadDIRECT; target_defined_modules = true)
+end

--- a/lib/OptimizationQuadDIRECT/test/runtests.jl
+++ b/lib/OptimizationQuadDIRECT/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationQuadDIRECT/test/test_groups.toml
+++ b/lib/OptimizationQuadDIRECT/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationSciPy/Project.toml
+++ b/lib/OptimizationSciPy/Project.toml
@@ -9,6 +9,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
@@ -18,6 +19,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5.1"
@@ -29,4 +31,4 @@ PythonCall = "0.9.24"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [targets]
-test = ["ForwardDiff", "ModelingToolkit", "Random", "ReverseDiff", "Test", "Zygote", "SafeTestsets"]
+test = ["ForwardDiff", "ModelingToolkit", "Random", "ReverseDiff", "Test", "Zygote", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationSciPy/test/qa/Project.toml
+++ b/lib/OptimizationSciPy/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationSciPy = "cce07bd8-c79b-4b00-aee8-8db9cce22837"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationSciPy = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationSciPy = "0.4"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationSciPy/test/qa/qa.jl
+++ b/lib/OptimizationSciPy/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationSciPy, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationSciPy)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationSciPy; target_defined_modules = true)
+end

--- a/lib/OptimizationSciPy/test/runtests.jl
+++ b/lib/OptimizationSciPy/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationSciPy/test/test_groups.toml
+++ b/lib/OptimizationSciPy/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationSophia/Project.toml
+++ b/lib/OptimizationSophia/Project.toml
@@ -9,6 +9,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
@@ -19,6 +20,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 ComponentArrays = "0.15.29"
 Lux = "1.16.0"
@@ -37,4 +39,4 @@ julia = "1.10"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [targets]
-test = ["Test", "ComponentArrays", "Lux", "MLUtils", "OrdinaryDiffEqTsit5", "SciMLSensitivity", "Zygote", "SafeTestsets"]
+test = ["Test", "ComponentArrays", "Lux", "MLUtils", "OrdinaryDiffEqTsit5", "SciMLSensitivity", "Zygote", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationSophia/test/qa/Project.toml
+++ b/lib/OptimizationSophia/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationSophia = "892fee11-dca1-40d6-b698-84ba0d87399a"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationSophia = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationSophia = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationSophia/test/qa/qa.jl
+++ b/lib/OptimizationSophia/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationSophia, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationSophia)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationSophia; target_defined_modules = true)
+end

--- a/lib/OptimizationSophia/test/runtests.jl
+++ b/lib/OptimizationSophia/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationSophia/test/test_groups.toml
+++ b/lib/OptimizationSophia/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OptimizationSpeedMapping/Project.toml
+++ b/lib/OptimizationSpeedMapping/Project.toml
@@ -9,11 +9,13 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5"
@@ -25,4 +27,4 @@ Reexport = "1.2"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [targets]
-test = ["ForwardDiff", "Test", "SafeTestsets"]
+test = ["ForwardDiff", "Test", "SafeTestsets", "Pkg"]

--- a/lib/OptimizationSpeedMapping/test/qa/Project.toml
+++ b/lib/OptimizationSpeedMapping/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OptimizationSpeedMapping = "3d669222-0d7d-4eb9-8a9f-d8528b0d9b91"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+OptimizationSpeedMapping = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+OptimizationSpeedMapping = "0.2"
+Test = "1"
+julia = "1.10"

--- a/lib/OptimizationSpeedMapping/test/qa/qa.jl
+++ b/lib/OptimizationSpeedMapping/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using OptimizationSpeedMapping, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimizationSpeedMapping)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(OptimizationSpeedMapping; target_defined_modules = true)
+end

--- a/lib/OptimizationSpeedMapping/test/runtests.jl
+++ b/lib/OptimizationSpeedMapping/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OptimizationSpeedMapping/test/test_groups.toml
+++ b/lib/OptimizationSpeedMapping/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/SimpleOptimization/Project.toml
+++ b/lib/SimpleOptimization/Project.toml
@@ -23,6 +23,7 @@ SimpleOptimizationEnzymeExt = "Enzyme"
 SimpleOptimizationForwardDiffExt = "ForwardDiff"
 
 [compat]
+Pkg = "1"
 SafeTestsets = "0.1"
 ADTypes = "1"
 Enzyme = "0.13"
@@ -34,9 +35,10 @@ SimpleNonlinearSolve = "1, 2"
 julia = "1.10"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ForwardDiff", "SafeTestsets"]
+test = ["Test", "ForwardDiff", "SafeTestsets", "Pkg"]

--- a/lib/SimpleOptimization/test/qa/Project.toml
+++ b/lib/SimpleOptimization/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SimpleOptimization = "510db2f7-4254-4e34-bbda-04240c91ca8f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+SimpleOptimization = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+SimpleOptimization = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/SimpleOptimization/test/qa/qa.jl
+++ b/lib/SimpleOptimization/test/qa/qa.jl
@@ -1,0 +1,10 @@
+using SimpleOptimization, Aqua, JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(SimpleOptimization)
+end
+
+@testset "JET static analysis" begin
+    JET.test_package(SimpleOptimization; target_defined_modules = true)
+end

--- a/lib/SimpleOptimization/test/runtests.jl
+++ b/lib/SimpleOptimization/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "OPTIMIZATION_TEST_GROUP", "All")
 
+# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
+# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
+# is ignored, so develop the package by path to test the PR branch code.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "Core" include("core_tests.jl")
+end
+
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/SimpleOptimization/test/test_groups.toml
+++ b/lib/SimpleOptimization/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
Part of SciML/.github#77: add canonical QA (Aqua + JET) groups to the sublibraries.

Each unit gets:
- `test/qa/Project.toml` — isolated QA environment (Aqua 0.8, JET 0.9/0.10/0.11, the package via `[sources]` path), so QA tooling deps never enter the main test target's resolve.
- `test/qa/qa.jl` — `Aqua.test_all` + `JET.test_package(...; target_defined_modules = true)`.
- A QA dispatch in `test/runtests.jl` gated on `OPTIMIZATION_TEST_GROUP == "QA"`, mirroring the root package's `test/qa` pattern (including the Julia < 1.11 `Pkg.develop` fallback since `[sources]` is ignored there).
- `Pkg` wired into the unit's test target (`[extras]` + `[targets]`, with a `[compat]` entry so Aqua `deps_compat` stays green).
- A `[QA]` cell in `test/test_groups.toml` with `versions = ["lts", "1"]` (no `pre`), picked up by the SublibraryCI matrix.

Units in this batch (9):
- lib/OptimizationAuglag
- lib/OptimizationBase
- lib/OptimizationBBO
- lib/OptimizationCMAEvolutionStrategy
- lib/OptimizationEvolutionary
- lib/OptimizationGCMAES
- lib/OptimizationIpopt
- lib/OptimizationLBFGSB
- lib/OptimizationMadNLP

Verification: static only (TOML parse, `Meta.parseall` of the new/changed `.jl` files, `[sources]` path resolution, Runic check on changed files all pass locally). QA findings that CI surfaces will be triaged per the established mark-broken+issue policy.

Further batches may be pushed to this branch. Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
