### PR TITLE
Fix downgrade CI config (julia_floor)

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -18,7 +18,10 @@ jobs:
     uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
     secrets: "inherit"
     with:
-      julia-version: "lts"
+      # The sublibrary downgrade resolver passes julia-version straight to
+      # `resolve.jl --julia=`, which requires a numeric registry-compat spec and
+      # rejects the "lts" channel alias. Pin to the numeric sublibrary floor.
+      julia-version: "1.10"
       # SymbolicAnalysis skipped: 0.3.x doesn't support Symbolics 7 (required by
       # ModelingToolkit 11). Stdlibs and in-repo sublibraries are auto-populated by
       # the centralized workflow.


### PR DESCRIPTION
## Problem

The `Downgrade Sublibraries` workflow fails at `julia-actions/julia-downgrade-compat@v2` (before buildpkg/runtest) for the `lib/*` sublibraries, e.g. for `lib/OptimizationLBFGSB`:

```
[ERROR] Invalid compat version spec: --julia=lts
ERROR: LoadError: failed process: Process(`... resolve.jl lib/OptimizationLBFGSB --min=@alldeps --julia=lts`, ProcessExited(1))
```

Root cause: the caller passed `julia-version: "lts"`, which the centralized `sublibrary-downgrade.yml@v1` forwards verbatim into `julia-downgrade-compat`'s sublibrary resolver as `resolve.jl --julia=lts`. The resolver only accepts a **numeric registry-compat** version spec (e.g. `1.10`), not the `lts` channel alias, so resolution aborts. (The fast-cancelled sibling matrix jobs are fail-fast cancellations of the same error.)

This is config-only. `lts` already resolved to `1.10.11` at setup, and the sublibrary `[compat] julia` floor is `"1.10"`, so pinning `julia-version: "1.10"` keeps the identical runtime while giving the resolver a value it accepts.

## Pre-existing vs introduced

`Downgrade Sublibraries` on `master` has been failing on this `lts` resolver error since the sublibrary downgrade workflow was centralized. The main (non-sublibrary) `Downgrade` workflow is green (it routes `lts` through `downgrade.yml@v1`, which converts it to a numeric spec).

## Change

Set `julia-version: "1.10"` (numeric sublibrary floor) in `.github/workflows/DowngradeSublibraries.yml`; the existing `skip: "SymbolicAnalysis"` and group env inputs are unchanged. No `Project.toml`, source, or test changes. `actionlint` passes.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)