### PR TITLE
Use SciMLTesting v1.2 (folder-based run_tests)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -72,6 +72,7 @@ SafeTestsets = "0.1"
 SciMLBase = "2.148.0, 3"
 SciMLLogging = "1.10.1, 2"
 SciMLSensitivity = "7.100.0"
+SciMLTesting = "1"
 SparseArrays = "1.10"
 Symbolics = "7"
 TerminalLoggers = "0.1"
@@ -109,6 +110,7 @@ ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 SciMLSensitivity = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -116,4 +118,4 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["BenchmarkTools", "Boltz", "ComponentArrays", "DiffEqFlux", "Enzyme", "FiniteDiff", "Flux", "ForwardDiff", "Ipopt", "IterTools", "LinearSolve", "Lux", "MLUtils", "ModelingToolkit", "Optim", "OptimizationLBFGSB", "OptimizationMOI", "OptimizationOptimJL", "OptimizationOptimisers", "OrdinaryDiffEqTsit5", "Pkg", "Random", "ReverseDiff", "SafeTestsets", "SciMLSensitivity", "SparseArrays", "Symbolics", "Test", "Tracker", "Zygote", "Mooncake", "SciMLLogging"]
+test = ["BenchmarkTools", "Boltz", "ComponentArrays", "DiffEqFlux", "Enzyme", "FiniteDiff", "Flux", "ForwardDiff", "Ipopt", "IterTools", "LinearSolve", "Lux", "MLUtils", "ModelingToolkit", "Optim", "OptimizationLBFGSB", "OptimizationMOI", "OptimizationOptimJL", "OptimizationOptimisers", "OrdinaryDiffEqTsit5", "Pkg", "Random", "ReverseDiff", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "SparseArrays", "Symbolics", "Test", "Tracker", "Zygote", "Mooncake", "SciMLLogging"]

--- a/test/downstream/Project.toml
+++ b/test/downstream/Project.toml
@@ -1,3 +1,14 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DiffEqFlux = "aae7a2af-3d4f-5e19-a356-7da93b79d9d0"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+Optimization = {path = "../.."}
+
+[compat]
+SafeTestsets = "0.0.1, 0.1"
+SciMLTesting = "1"
+Test = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,6 +2,8 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -11,5 +13,7 @@ Optimization = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 Optimization = "5"
+SafeTestsets = "0.0.1, 0.1"
+SciMLTesting = "1"
 Test = "1.10"
 julia = "1.10"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,59 +1,29 @@
 using Pkg
 using SafeTestsets, Test
+using SciMLTesting
 
-const GROUP = get(ENV, "GROUP", "Core")
-
-function activate_downstream_env()
-    Pkg.activate("downstream")
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    return Pkg.instantiate()
-end
-
-# QA (Aqua + JET) runs in an isolated environment (test/qa) so its tooling deps
-# never enter the main test target's resolve. On Julia < 1.11 the [sources] table
-# is ignored, so develop the package by path to test the PR branch code.
-function activate_qa_env()
-    Pkg.activate(joinpath(@__DIR__, "qa"))
-    if VERSION < v"1.11.0-DEV.0"
-        Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    end
-    return Pkg.instantiate()
-end
+const GROUP = current_group(; default = "Core")
+const LIB_DIR = joinpath(dirname(@__DIR__), "lib")
 
 @time begin
-    # Detect sublibrary test groups.
-    # GROUP can be a bare sublibrary name (Core test group) or
-    # "{sublibrary}_{TEST_GROUP}" for any custom group (e.g., QA, GPU, etc.).
-    # Sublibraries declare their groups in test/test_groups.toml.
-    lib_dir = joinpath(dirname(@__DIR__), "lib")
+    # Monorepo sublibrary routing: a bare sublibrary name (its Core group) or
+    # "<sublibrary>_<group>" selects a lib/<Sublibrary> sub-package, which is
+    # activated and `Pkg.test`ed with OPTIMIZATION_TEST_GROUP set. This pre-step is
+    # kept explicit (not delegated to run_tests' lib_dir routing) to preserve the
+    # `--check-bounds=auto` julia arg, `force_latest_compatible_version = false`, and
+    # the pre-1.11 transitive [sources] develop walk byte-for-byte.
+    base_group, test_group = detect_sublibrary_group(GROUP, LIB_DIR)
 
-    # Check if GROUP matches a sublibrary, possibly with a _SUFFIX for the test group.
-    # Scan underscores right-to-left to find the longest matching sublibrary prefix.
-    function _detect_sublibrary_group(group, lib_dir)
-        isdir(joinpath(lib_dir, group)) && return (group, "Core")
-        for i in length(group):-1:1
-            if group[i] == '_' && isdir(joinpath(lib_dir, group[1:(i - 1)]))
-                return (group[1:(i - 1)], group[(i + 1):end])
-            end
-        end
-        return (group, "Core")
-    end
-    base_group, test_group = _detect_sublibrary_group(GROUP, lib_dir)
-
-    if isdir(joinpath(lib_dir, base_group))
-        Pkg.activate(joinpath(lib_dir, base_group))
-        # On Julia < 1.11, the [sources] section in Project.toml is not supported.
-        # Manually Pkg.develop local path dependencies so CI tests the PR branch code.
-        # We resolve transitively: each developed dependency's own [sources] are also
-        # developed, so sibling sublibraries reachable through a chain of [sources]
-        # (e.g. OptimizationBase under OptimizationNLPModels) are correctly found.
+    if !isempty(base_group) && isdir(joinpath(LIB_DIR, base_group))
+        Pkg.activate(joinpath(LIB_DIR, base_group))
+        # On Julia < 1.11 the [sources] table is ignored, so manually develop local
+        # path dependencies (transitively, following each dep's own [sources]) so CI
+        # tests the PR-branch code.
         if VERSION < v"1.11.0-DEV.0"
             developed = Set{String}()
-            # Never develop the active project itself; Pkg refuses with "package <X>
-            # has the same name or UUID as the active project".
-            push!(developed, normpath(joinpath(lib_dir, base_group)))
+            push!(developed, normpath(joinpath(LIB_DIR, base_group)))
             specs = Pkg.PackageSpec[]
-            queue = [joinpath(lib_dir, base_group)]
+            queue = [joinpath(LIB_DIR, base_group)]
             while !isempty(queue)
                 pkg_dir = popfirst!(queue)
                 toml_path = joinpath(pkg_dir, "Project.toml")
@@ -83,25 +53,35 @@ end
                 allow_reresolve = true
             )
         end
-    elseif GROUP == "Core"
-        @testset verbose = true "Optimization.jl" begin
-            @safetestset "Utils Tests" include("utils.jl")
-            @safetestset "Verbosity Tests" include("verbosity.jl")
-            @safetestset "AD Tests" include("ADtests.jl")
-            @safetestset "AD Performance Regression Tests" include("AD_performance_regression.jl")
-            @safetestset "Optimization" include("native.jl")
-            @safetestset "Mini batching" include("minibatch.jl")
-            # DiffEqFlux test temporarily skipped due to ForwardDiff gradient dispatch issue
-            # with Float32 ComponentArrays. See GitHub issue for tracking.
-            # @safetestset "DiffEqFlux" include("diffeqfluxtests.jl")
-            @safetestset "Interface Compatibility" include("interface_tests.jl")
-            @safetestset "Sense Handling" include("sense_tests.jl")
-        end
-    elseif GROUP == "QA"
-        activate_qa_env()
-        @safetestset "Quality Assurance" include("qa/qa.jl")
-    elseif GROUP == "GPU"
-        activate_downstream_env()
-        @safetestset "DiffEqFlux GPU" include("downstream/gpu_neural_ode.jl")
+    else
+        run_tests(;
+            default = "Core",
+            core = function ()
+                @safetestset "Utils Tests" include("utils.jl")
+                @safetestset "Verbosity Tests" include("verbosity.jl")
+                @safetestset "AD Tests" include("ADtests.jl")
+                @safetestset "AD Performance Regression Tests" include("AD_performance_regression.jl")
+                @safetestset "Optimization" include("native.jl")
+                @safetestset "Mini batching" include("minibatch.jl")
+                # DiffEqFlux test temporarily skipped due to ForwardDiff gradient dispatch
+                # issue with Float32 ComponentArrays. See GitHub issue for tracking.
+                # @safetestset "DiffEqFlux" include("diffeqfluxtests.jl")
+                @safetestset "Interface Compatibility" include("interface_tests.jl")
+                @safetestset "Sense Handling" include("sense_tests.jl")
+            end,
+            groups = Dict(
+                "GPU" => (;
+                    env = joinpath(@__DIR__, "downstream"),
+                    body = function ()
+                        @safetestset "DiffEqFlux GPU" include("downstream/gpu_neural_ode.jl")
+                    end,
+                ),
+            ),
+            qa = (;
+                env = joinpath(@__DIR__, "qa"),
+                body = joinpath(@__DIR__, "qa", "qa.jl"),
+            ),
+            all = String[],
+        )
     end
 end


### PR DESCRIPTION
Converts the root test suite to the SciMLTesting v1.2 `run_tests` harness.

Optimization.jl is a monorepo (`lib/<Sublibrary>` sub-packages, `OPTIMIZATION_TEST_GROUP` sublibrary handoff) with a `GPU` group that activates its own `test/downstream` environment, so the **explicit-args** form of `run_tests` is used — folder-discovery mode cannot express sublibrary routing or a per-group sub-environment. The sublibrary pre-step is kept verbatim so its `--check-bounds=auto` julia arg, `force_latest_compatible_version = false`, and the pre-1.11 transitive `[sources]` develop walk are preserved byte-for-byte.

Behavior preserved (verified by simulating the dispatch on Julia 1.11):
- `GROUP=Core` runs the same 8 top-level files (utils, verbosity, ADtests, AD_performance_regression, native, minibatch, interface_tests, sense_tests); `diffeqfluxtests.jl` stays commented out.
- `GROUP=QA` activates `test/qa` and runs `qa/qa.jl`.
- `GROUP=GPU` activates `test/downstream` and runs `downstream/gpu_neural_ode.jl`.
- A bare `lib/<Sublibrary>` name (or `<Sublibrary>_<group>`) still routes to that sublibrary; `Core`/`QA`/`GPU`/`All` are never misrouted.
- `GROUP=All` is a no-op, matching the old dispatcher (no `All` branch existed; default was `Core`).

Dep edits: add `SciMLTesting` to the root test deps and to `test/qa/Project.toml` and `test/downstream/Project.toml` (both run `@safetestset` bodies; `SafeTestsets`/`Test` added there too). `Pkg` is kept (the sublibrary pre-step uses it). `test/test_groups.toml` is unchanged.

Static-verified: TOML parse of every Project.toml + test_groups.toml; `Meta.parseall` of runtests.jl, qa.jl, and every included test file; Runic-clean.

Ignore until reviewed by @ChrisRackauckas.
