### PR TITLE
Forward solver kwargs to CMAEvolutionStrategy

### DIFF
--- a/lib/OptimizationCMAEvolutionStrategy/Project.toml
+++ b/lib/OptimizationCMAEvolutionStrategy/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationCMAEvolutionStrategy"
 uuid = "bd407f91-200f-4536-9381-e4ba712f53f8"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 [deps]
 CMAEvolutionStrategy = "8d3b24bd-414e-49e0-94fb-163cc3a3e411"
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"

--- a/lib/OptimizationCMAEvolutionStrategy/Project.toml
+++ b/lib/OptimizationCMAEvolutionStrategy/Project.toml
@@ -19,6 +19,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 [compat]
 Pkg = "1"
 SafeTestsets = "0.1"
+Test = "1"
 CMAEvolutionStrategy = "0.2"
 julia = "1.10"
 OptimizationBase = "5"

--- a/lib/OptimizationCMAEvolutionStrategy/src/OptimizationCMAEvolutionStrategy.jl
+++ b/lib/OptimizationCMAEvolutionStrategy/src/OptimizationCMAEvolutionStrategy.jl
@@ -42,7 +42,12 @@ function __map_optimizer_args(
         maxtime::Union{Number, Nothing} = nothing,
         abstol::Union{Number, Nothing} = nothing,
         reltol::Union{Number, Nothing} = nothing,
-        verbose::Bool = false
+        verbose::Bool = false,
+        # `sigma0` is the initial step size; it is the positional `s0` argument of
+        # `CMAEvolutionStrategy.minimize`, so it is handled in `__solve` and only
+        # captured here to keep it out of the forwarded `kwargs`.
+        sigma0 = nothing,
+        kwargs...
     )
     if !isnothing(reltol)
         @SciMLMessage(
@@ -51,7 +56,9 @@ function __map_optimizer_args(
         )
     end
 
+    mapped_args = (; kwargs...)
     mapped_args = (;
+        mapped_args...,
         lower = prob.lb,
         upper = prob.ub,
         logger = CMAEvolutionStrategy.BasicLogger(
@@ -110,8 +117,10 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: CMAEvolution
         maxtime = maxtime
     )
 
+    sigma0 = get(cache.solver_args, :sigma0, 0.1)
+
     t0 = time()
-    opt_res = CMAEvolutionStrategy.minimize(_loss, cache.u0, 0.1; opt_args...)
+    opt_res = CMAEvolutionStrategy.minimize(_loss, cache.u0, sigma0; opt_args...)
     t1 = time()
 
     opt_ret = _cma_retcode(opt_res.stop.reason)

--- a/lib/OptimizationCMAEvolutionStrategy/test/core_tests.jl
+++ b/lib/OptimizationCMAEvolutionStrategy/test/core_tests.jl
@@ -27,6 +27,21 @@ using Test
     sol_maxit = solve(prob, CMAEvolutionStrategyOpt(), maxiters = 2)
     @test sol_maxit.retcode == SciMLBase.ReturnCode.MaxIters
 
+    @testset "solver kwargs are forwarded" begin
+        # `popsize` is a keyword of `CMAEvolutionStrategy.minimize`; `sigma0` is its
+        # positional `s0` (initial step size). Both should be reachable through solve.
+        sol_kw = solve(prob, CMAEvolutionStrategyOpt(); popsize = 20, maxiters = 10)
+        @test sol_kw.original.p.λ == 20
+
+        sol_default = solve(prob, CMAEvolutionStrategyOpt(); maxiters = 10)
+        @test sol_default.original.p.λ != 20
+
+        sol_sigma = solve(
+            prob, CMAEvolutionStrategyOpt(); sigma0 = 0.5, maxiters = 10
+        )
+        @test sol_sigma.retcode isa SciMLBase.ReturnCode.T
+    end
+
     @testset "_cma_retcode symbol mapping" begin
         _cma_retcode = OptimizationCMAEvolutionStrategy._cma_retcode
         @test _cma_retcode(:ftarget) == SciMLBase.ReturnCode.Success


### PR DESCRIPTION
Fixes #1226.

## Problem

`__map_optimizer_args` for `OptimizationCMAEvolutionStrategy` did not forward extra solver kwargs to `CMAEvolutionStrategy.minimize`, so options like `popsize`, `sigma0` (#1074), `noise_handling`, `seed`, etc. were unreachable through Optimization.jl. The equivalent methods for `OptimizationBBO` and `OptimizationEvolutionary` do forward kwargs.

## Fix

- Add a `kwargs...` capture to `__map_optimizer_args` and splat it into the mapped args, matching the OptimizationBBO/OptimizationEvolutionary pattern. Explicitly-mapped args (`lower`, `upper`, `logger`, `maxiter`, `maxtime`, `ftol`) are applied after the user kwargs so they still take precedence.
- `sigma0` is the *positional* `s0` argument of `minimize` (the initial step size, previously hardcoded to `0.1`), so it cannot ride along in the kwargs. It is now pulled from `solver_args` in `__solve` and passed positionally (default `0.1`), and is captured (but unused) in `__map_optimizer_args` so it doesn't leak into the forwarded kwargs.

## Tests

Added a `solver kwargs are forwarded` testset verifying:
- `popsize = 20` is reflected in `sol.original.p.λ`,
- the default run does not use that popsize,
- `sigma0 = 0.5` runs and returns a valid retcode.

Full package test suite passes locally (16/16).

## QA group

Also declares a `Test = "1"` `[compat]` entry in this sublibrary's `Project.toml`. `Test` was already listed in `[extras]` but had no compat bound, so Aqua's `deps_compat` (`check_extras`) assertion failed the sublibrary **QA** group. This fixes the extras-compat finding. Verified locally (CI-equivalent develop + `Pkg.test`, `OPTIMIZATION_TEST_GROUP=QA`):
- QA / Julia 1: passes (12/12).
- QA / Julia lts: extras-compat now passes.

### Pre-existing QA-lts failure NOT addressed here (out of scope)

On Julia < 1.11, the QA-lts job still reports two Aqua findings — `Stale dependencies` and `deps`-compat for `OptimizationLBFGSB` / `OptimizationManopt`. These are **not** introduced by this PR and reproduce identically on `master`. Root cause: `lib/OptimizationBase/Project.toml` declares a `[sources]` table for its *test-only* deps `OptimizationLBFGSB` / `OptimizationManopt`, and the centralized `SciML/.github` `tests.yml` "develop in-repo [sources]" helper walks the `[sources]` graph **transitively** on Julia < 1.11 — so when any sublibrary develops `OptimizationBase`, those two test-only path-deps get `Pkg.develop`ed into the sublibrary's environment as phantom direct deps, which Aqua then flags. On Julia ≥ 1.11 the helper is a no-op, which is why QA / Julia 1 is green. The proper fix belongs in `OptimizationBase` (don't expose test-only `[sources]`) or in the `.github` develop helper (don't transitively develop a dep's test `[sources]`), and affects every OptimizationBase-dependent sublibrary — out of scope for a CMAES-kwargs PR.

---
Please ignore until reviewed by @ChrisRackauckas.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>