### PR TITLE
Fix Downgrade-CI stale floors (ODE, SimpleOptimization, QuadDIRECT) + CCMO test detection

### DIFF
--- a/lib/OptimizationMetaheuristics/test/core_tests.jl
+++ b/lib/OptimizationMetaheuristics/test/core_tests.jl
@@ -145,7 +145,11 @@ Random.seed!(42)
                         ) -> prob_func(x)
                     )
                     prob = OptimizationProblem(multi_obj_fun, lb; lb = lb, ub = ub)
-                    if (alg_name == "Metaheuristics.Algorithm{CCMO{NSGA2}}")
+                    # CCMO wraps a base algorithm and has no `N` on its own
+                    # parameters, so the `use_initial` seeding path does not apply.
+                    # Detect it by type rather than a stringified type name, which
+                    # is fragile across Metaheuristics' type-printing changes.
+                    if alg.parameters isa Metaheuristics.CCMO
                         sol = solve(prob, alg)
                     else
                         sol = solve(prob, alg; maxiters = 10000, use_initial = true)

--- a/lib/OptimizationODE/Project.toml
+++ b/lib/OptimizationODE/Project.toml
@@ -1,51 +1,52 @@
 name = "OptimizationODE"
 uuid = "dfa73e59-e644-4d8a-bf84-188d7ecb34e4"
 authors = ["Paras Puneet Singh <paras.puneet2204@gmail.com>"]
-version = "0.1.6"
+version = "0.1.7"
+
 [deps]
-ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
-OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
-OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
-OrdinaryDiffEqStabilizedRK = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
-NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-
-[compat]
-Pkg = "1"
-SafeTestsets = "0.1"
-ADTypes = "1.18"
-DiffEqBase = "6.190.2, 7"
-ForwardDiff = "0.10, 1"
-OptimizationBase = "5"
-OrdinaryDiffEqLowOrderRK = "1, 2"
-OrdinaryDiffEqNonlinearSolve = "1, 2"
-OrdinaryDiffEqRosenbrock = "1, 2"
-OrdinaryDiffEqStabilizedRK = "1, 2"
-OrdinaryDiffEqTsit5 = "1.2.0, 2"
-OrdinaryDiffEqVerner = "1, 2"
-NonlinearSolve = "4.11"
-Reexport = "1"
-SciMLBase = "2.122.1, 3"
-SteadyStateDiffEq = "2.5"
-julia = "1.10"
-
-[sources]
-OptimizationBase = {path = "../OptimizationBase"}
+OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+OrdinaryDiffEqStabilizedRK = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+OrdinaryDiffEqNonlinearSolve = "127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+
+[compat]
+Pkg = "1"
+NonlinearSolve = "4.11"
+ForwardDiff = "0.10, 1"
+OptimizationBase = "5"
+OrdinaryDiffEqTsit5 = "2"
+OrdinaryDiffEqVerner = "2"
+SciMLBase = "3"
+SteadyStateDiffEq = "2.5"
+OrdinaryDiffEqLowOrderRK = "2"
+OrdinaryDiffEqStabilizedRK = "2"
+julia = "1.10"
+ADTypes = "1.18"
+OrdinaryDiffEqNonlinearSolve = "2"
+OrdinaryDiffEqRosenbrock = "2"
+DiffEqBase = "7"
+SafeTestsets = "0.1"
+Reexport = "1"
 
 [targets]
 test = ["Sundials", "Test", "SafeTestsets", "Pkg"]
+
+[sources.OptimizationBase]
+path = "../OptimizationBase"

--- a/lib/OptimizationQuadDIRECT/Project.toml
+++ b/lib/OptimizationQuadDIRECT/Project.toml
@@ -1,7 +1,8 @@
 name = "OptimizationQuadDIRECT"
 uuid = "842ac81e-713d-465f-80f7-84eddaced298"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.5"
+version = "0.3.6"
+
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 QuadDIRECT = "dae52e8d-d666-5120-a592-9e15c33b8d7a"
@@ -9,20 +10,21 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [compat]
 Pkg = "1"
-SafeTestsets = "0.1"
 julia = "1.10"
 OptimizationBase = "5"
+QuadDIRECT = "0.1.2"
 SciMLBase = "2.58, 3"
+SafeTestsets = "0.1"
 Reexport = "1.2"
-
-[sources]
-OptimizationBase = {path = "../OptimizationBase"}
 
 [targets]
 test = ["Pkg", "Test", "SafeTestsets"]
+
+[sources.OptimizationBase]
+path = "../OptimizationBase"

--- a/lib/SimpleOptimization/Project.toml
+++ b/lib/SimpleOptimization/Project.toml
@@ -1,44 +1,44 @@
 name = "SimpleOptimization"
+version = "1.2.2"
 uuid = "510db2f7-4254-4e34-bbda-04240c91ca8f"
 authors = ["Utkarsh <rajpututkarsh530@gmail.com> and contributors"]
-version = "1.2.1"
 
-[deps]
-ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
+[targets]
+test = ["Test", "ForwardDiff", "SafeTestsets", "Pkg"]
+
+[compat]
+SimpleNonlinearSolve = "2"
+Pkg = "1"
+julia = "1.10"
+ForwardDiff = "0.10, 1"
+ADTypes = "1"
+OptimizationBase = "5"
+SciMLBase = "2.122.1, 3"
+SafeTestsets = "0.1"
+Enzyme = "0.13"
+Reexport = "1.2"
 
 [weakdeps]
-Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 
-[sources]
-OptimizationBase = {path = "../OptimizationBase"}
+[deps]
+OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
+
+[extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+
+[sources.OptimizationBase]
+path = "../OptimizationBase"
 
 [extensions]
 SimpleOptimizationEnzymeExt = "Enzyme"
 SimpleOptimizationForwardDiffExt = "ForwardDiff"
-
-[compat]
-Pkg = "1"
-SafeTestsets = "0.1"
-ADTypes = "1"
-Enzyme = "0.13"
-ForwardDiff = "0.10, 1"
-OptimizationBase = "5"
-Reexport = "1.2"
-SciMLBase = "2.122.1, 3"
-SimpleNonlinearSolve = "1, 2"
-julia = "1.10"
-
-[extras]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test", "ForwardDiff", "SafeTestsets", "Pkg"]


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Fixes red lanes on the master **Downgrade Sublibraries** run. Each reproduced locally with the real `julia-actions/julia-downgrade-compat@v2` (Resolver.jl `--min=@alldeps`, julia=lts) merged-test-deps path, then verified with `Pkg.test` on Julia lts (1.10).

### 1. OptimizationODE — coordinated stale floors
`OrdinaryDiffEq*` subpackages had `1` floors whose registry compat permits a modern `OrdinaryDiffEqCore` but whose **code** does not; the downgrade hit, in sequence: `no method matching get_fsalfirstlast(::Vern6Cache,...)` (Verner 1.0.0), `UndefVarError: namify not defined` (Rosenbrock 1.5.0), then `type Nothing has no field alias_f`, then `no method matching _process_verbose_param(::NonlinearVerbosity{...})`. Raise `OrdinaryDiffEq* = "2"`, `SciMLBase = "3"`, `DiffEqBase = "7"` -> resolves onto the modern stack (the one max already uses). **Verified (lts):** downgrade -> Core 4.3.0 / SciMLBase 3.1.0 / DiffEqBase 7.0.0 -> tests pass; max also still passes.

### 2. SimpleOptimization — stale `SimpleNonlinearSolve` floor
`"1, 2"` picked SimpleNonlinearSolve 1.8.0 -> `AbstractNonlinearTerminationMode` removed from resolved DiffEqBase -> precompile `UndefVarError`. Raise floor to `"2"`. **Verified:** downgrade -> SimpleNonlinearSolve 2.5.0 -> tests pass.

### 3. OptimizationQuadDIRECT — missing compat floor
No `QuadDIRECT` compat entry at all, so the downgrade floored to QuadDIRECT 0.0.1, whose `split_insert!` throws `AssertionError: xsplit[1] < xsplit[2] < xsplit[3]`. Add `QuadDIRECT = "0.1.2"`. **Verified:** downgrade -> QuadDIRECT 0.1.2 -> tests pass.

### 4. OptimizationMetaheuristics — broken CCMO detection (red at downgrade AND max)
The multi-objective test special-cased CCMO (no `N` on its own parameters -> `use_initial` seeding inapplicable) via `alg_name == "Metaheuristics.Algorithm{CCMO{NSGA2}}"`. Metaheuristics now prints the type fully qualified, so the string never matches; CCMO took the `use_initial=true` branch -> `type CCMO has no field N` (6 errored every problem), failing at the latest Metaheuristics 3.5.0 too. Replace with a robust `alg.parameters isa Metaheuristics.CCMO` check. **Verified at both max and downgrade.**

### Not in this PR (recorded, no change)
- **OptimizationBase / root Downgrade Core:** Resolver.jl `Unsatisfiable` in `--min=@alldeps`, driven by **Mooncake** in merged test deps (removing Mooncake -> resolves). Fleet-wide Resolver.jl wall, not `[compat]`-fixable.
- **OptimizationBase Sublibrary Downgrade:** `SymbolicAnalysis 0.3` (caps Symbolics <=6) cannot coexist with `Symbolics 7` — unsatisfiable for Pkg too; `skip: SymbolicAnalysis` only skips its compat-downgrade, not its graph presence. Blocked on **SciML/SymbolicAnalysis.jl** gaining Symbolics 7 support (separate upstream PR). OptimizationBase also has a malformed test target (6 regular `[deps]` in `targets.test` but not `[extras]`, rejected by `Pkg.test`) — left out since it can't be verified green while SymbolicAnalysis blocks resolution.
- **CI Core (julia pre):** self-hosted runner lost communication (`smcsd`) — infra flake, passes locally.
- **OptimizationAuglag / OptimizationNLPModels Downgrade:** pass cleanly locally at the downgrade floor — CI reds appear transient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
