### PR TITLE
Fix invalid setfield! fallback in MOIOptimizationNLPCache setproperty!

### DIFF
--- a/lib/OptimizationMOI/src/nlp.jl
+++ b/lib/OptimizationMOI/src/nlp.jl
@@ -48,7 +48,9 @@ function Base.setproperty!(cache::MOIOptimizationNLPCache{E}, name::Symbol, x) w
     elseif name in fieldnames(OptimizationBase.ReInitCache)
         return setfield!(cache.evaluator.reinit_cache, name, x)
     end
-    return setfield!(cache, name, x)
+    # The cache itself is immutable; its own fields delegate reads through
+    # `getproperty` but are never reassigned, so there is no valid setter.
+    throw(ArgumentError(lazy"field `$name` of `MOIOptimizationNLPCache` is immutable and cannot be set"))
 end
 
 function SciMLBase.get_p(


### PR DESCRIPTION
## Summary

`MOIOptimizationNLPCache` is an immutable struct whose custom `setproperty!` delegates mutation to the (mutable) `evaluator` and its `ReInitCache`. The final fallback called `setfield!(cache, name, x)` on the immutable cache itself — which can never succeed and which JET (`report_package`) flags as a guaranteed error:

```
setproperty!(cache::MOIOptimizationNLPCache{E}, name::Symbol, x::Any) @ nlp.jl:51
  setfield!: immutable struct of type MOIOptimizationNLPCache{E} cannot be changed
```

This replaces the dead fallback with an explicit, informative `ArgumentError`. Functionally equivalent (both error), but it makes the intent clear and removes the JET finding.

## Testing

Verified with `JET.test_package(OptimizationMOI; target_defined_modules = true)` locally on Julia 1.12.6: the `setproperty!`/`setfield!` finding is gone.

## Relationship to #1235

The OptimizationMOI QA (Aqua + JET) job is red on `master` for three independent reasons. #1235 fixes the two Aqua findings (allowed-piracy declaration + missing `ReverseDiff` compat) and the `cache.verbose` JET finding; this PR fixes the remaining `setproperty!` JET finding. I confirmed locally that with **both** PRs applied, `JET.test_package` passes cleanly (0 errors) and Aqua passes 11/11 — i.e. the two together turn the QA job green. Neither is individually sufficient.

---

**This PR is a draft and should be ignored until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtJAi7bALH5XkakjS6Yb6j
