### PR TITLE
Raise Mooncake compat floor to 0.5.36 (fix Downgrade resolution)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Optimization"
 uuid = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
-version = "5.6.2"
+version = "5.6.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -54,7 +54,7 @@ LoggingExtras = "0.4, 1"
 Lux = "1.12.4"
 MLUtils = "0.4"
 ModelingToolkit = "11"
-Mooncake = "0.4.138, 0.5"
+Mooncake = "0.5.36"
 Optim = ">= 1.4.1"
 Optimisers = ">= 0.2.5"
 OptimizationBase = "5"

--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.1.4"
+version = "5.1.5"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]
@@ -65,7 +65,7 @@ LinearAlgebra = "1.9, 1.10"
 Lux = "1.12"
 MLDataDevices = "1"
 MLUtils = "0.4"
-Mooncake = "0.4.138, 0.5"
+Mooncake = "0.5.36"
 Manifolds = "0.10, 0.11"
 ModelingToolkit = "11"
 Optim = ">= 1.4.1"


### PR DESCRIPTION
Raises the Mooncake `[compat]` floor to the latest (`0.5.36`) in every Project.toml that declares it, replacing the `Mooncake = "0.4.138, 0.5"` union with a single floor. This is the "limit to latest Mooncake" fix for the promotion-caused Downgrade `Unsatisfiable` wall: the old union let the Downgrade min-resolution pin an ancient Mooncake (verified: master pins **0.5.15**), whose promotion into the merged test env is what drove the Resolver.jl wall. A single floor at the latest stops the ancient pin.

## Raised floors

| Project.toml | old Mooncake compat | new |
| --- | --- | --- |
| `Project.toml` (Optimization) | `0.4.138, 0.5` | `0.5.36` |
| `lib/OptimizationBase/Project.toml` | `0.4.138, 0.5` | `0.5.36` |

Patch version bumps: Optimization `5.6.2 -> 5.6.3`, OptimizationBase `5.1.4 -> 5.1.5` (a [compat] narrowing on a weakdep/test dep is not a public-API change).

## Verification (resolves_at_min = TRUE)

Ran the actual `julia-actions/julia-downgrade-compat@v2` `downgrade.jl` (merged-extras resolution via Resolver.jl `--min=@deps`) on **Julia 1.12**, same skip list CI uses (stdlibs + `SymbolicAnalysis` + `[sources]`):

- **Root `Optimization` (merged extras, Mooncake promoted to a full dep):** `Successfully resolved minimal versions` — Mooncake pinned to exactly **0.5.36**. No `Unsatisfiable`.
- **`lib/OptimizationBase` (Mooncake weakdep, merged extras):** `Successfully resolved minimal versions`. No `Unsatisfiable`.
- Counterfactual baseline (unbumped master) resolved to Mooncake **0.5.15**, confirming the floor-raise is what forces the min-resolution up to 0.5.36.

So the floor-raise alone resolves the min-resolution here; the Resolver-capacity wall (#52) does **not** persist for these projects after the bump.

---

Ignore until reviewed by @ChrisRackauckas.