### PR TITLE
Fix stale docs examples on current SciMLBase

### DIFF
--- a/docs/src/tutorials/ensemble.md
+++ b/docs/src/tutorials/ensemble.md
@@ -27,14 +27,14 @@ This results is compared to a multistart approach with 4 random initial points:
 
 ```@example ensemble
 x0s = [x0, x0 .+ rand(2), x0 .+ rand(2), x0 .+ rand(2)]
-function prob_func(prob, i, repeat)
-    remake(prob, u0 = x0s[i])
+function prob_func(prob, ctx)
+    remake(prob, u0 = x0s[ctx.sim_id])
 end
 
 ensembleprob = EnsembleProblem(prob; prob_func)
 @time sol = solve(ensembleprob, OptimizationOptimJL.BFGS(),
     EnsembleThreads(), trajectories = 4, maxiters = 5)
-@show findmin(i -> sol[i].objective, 1:4)[1]
+@show minimum(s.objective for s in sol.u)
 ```
 
 With the same number of iterations (5) we get a much lower (1/100th) objective value by using multiple initial points. The initialization strategy used here was a pretty trivial one but approaches based on Quasi-Monte Carlo sampling should be typically more effective.

--- a/docs/src/tutorials/remakecomposition.md
+++ b/docs/src/tutorials/remakecomposition.md
@@ -46,7 +46,7 @@ res1 = solve(prob, BBO_adaptive_de_rand_1_bin(), maxiters = 4000)
 This is a good start can we converge to the global optimum?
 
 ```@example polyalg
-prob = remake(prob, u0 = res1.minimizer)
+prob = remake(prob, u0 = res1.u)
 res2 = solve(prob, OptimizationLBFGSB.LBFGSB(), maxiters = 100)
 
 @show res2.objective


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- update the multistart ensemble tutorial to use the current `prob_func(prob, ctx)` callback API
- read ensemble objectives through `sol.u` instead of indexing into the minimizer values
- use `res1.u` instead of the removed `OptimizationSolution.minimizer` field

## Verification
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --project=docs -e '...'` for the edited ensemble example: passed, observed `minimum((s.objective for s = sol.u)) = 0.01789620302945039`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --project=docs -e '...'` for the edited remake/composition example: passed, observed `res2.objective = 236.8767965046074`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --project=docs docs/make.jl`: passed locally; Documenter finished rendering HTML and skipped deployment outside CI
