### PR TITLE
Fix downgraded sublibrary compat bounds

### DIFF
--- a/lib/OptimizationBBO/Project.toml
+++ b/lib/OptimizationBBO/Project.toml
@@ -9,6 +9,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -19,6 +20,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
 BlackBoxOptim = "0.6.3"
+LogExpFunctions = "0.3.28 - 0.3"
 OptimizationBase = "5"
 Pkg = "1"
 Random = "1.10"
@@ -29,4 +31,4 @@ Test = "1.10"
 julia = "1.10"
 
 [targets]
-test = ["Random", "Test", "SafeTestsets", "Pkg"]
+test = ["Random", "Test", "SafeTestsets", "Pkg", "LogExpFunctions"]

--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -48,7 +48,7 @@ OptimizationLBFGSB = {path = "../OptimizationLBFGSB"}
 OptimizationManopt = {path = "../OptimizationManopt"}
 
 [compat]
-ADTypes = "1.14"
+ADTypes = "1.18"
 Aqua = "0.8"
 ArrayInterface = "7.6"
 BenchmarkTools = "1"
@@ -81,7 +81,7 @@ SafeTestsets = ">= 0.0.1"
 SciMLBase = "2.122.1, 3"
 SciMLLogging = "1.10.1, 2"
 SparseArrays = "1.10"
-SparseConnectivityTracer = "0.6, 1"
+SparseConnectivityTracer = "1"
 SparseMatrixColorings = "0.4"
 SymbolicAnalysis = "0.3"
 SymbolicIndexingInterface = "0.3.46"

--- a/lib/OptimizationEvolutionary/Project.toml
+++ b/lib/OptimizationEvolutionary/Project.toml
@@ -9,6 +9,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -19,6 +20,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
 Evolutionary = "0.11"
+LogExpFunctions = "0.3.28 - 0.3"
 OptimizationBase = "5"
 Pkg = "1"
 Random = "1.10"
@@ -29,4 +31,4 @@ Test = "1.10"
 julia = "1.10"
 
 [targets]
-test = ["Random", "Test", "SafeTestsets", "Pkg"]
+test = ["Random", "Test", "SafeTestsets", "Pkg", "LogExpFunctions"]

--- a/lib/OptimizationNOMAD/Project.toml
+++ b/lib/OptimizationNOMAD/Project.toml
@@ -9,6 +9,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [extras]
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -17,6 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
+LogExpFunctions = "0.3.28 - 0.3"
 Pkg = "1"
 SafeTestsets = "0.1"
 julia = "1.10"
@@ -27,4 +29,4 @@ Reexport = "1.2"
 Test = "1.10"
 
 [targets]
-test = ["Test", "SafeTestsets", "Pkg"]
+test = ["Test", "SafeTestsets", "Pkg", "LogExpFunctions"]

--- a/lib/OptimizationSciPy/Project.toml
+++ b/lib/OptimizationSciPy/Project.toml
@@ -9,6 +9,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [extras]
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -20,6 +21,7 @@ ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 
 [compat]
 ForwardDiff = "0.10, 1"
+LogExpFunctions = "0.3.28 - 0.3"
 ModelingToolkit = "11"
 OptimizationBase = "5.1"
 Pkg = "1"
@@ -37,4 +39,4 @@ julia = "1.10"
 OptimizationBase = {path = "../OptimizationBase"}
 
 [targets]
-test = ["ForwardDiff", "ModelingToolkit", "Random", "ReverseDiff", "Test", "Zygote", "SafeTestsets", "Pkg"]
+test = ["ForwardDiff", "ModelingToolkit", "Random", "ReverseDiff", "Test", "Zygote", "SafeTestsets", "Pkg", "LogExpFunctions"]

--- a/lib/SimpleOptimization/Project.toml
+++ b/lib/SimpleOptimization/Project.toml
@@ -16,6 +16,8 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SimpleNonlinearSolve = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 
 [extras]
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -29,18 +31,20 @@ SimpleOptimizationEnzymeExt = "Enzyme"
 SimpleOptimizationForwardDiffExt = "ForwardDiff"
 
 [compat]
-ADTypes = "1.14"
+ADTypes = "1.18"
 Enzyme = "0.13"
+DifferentiationInterface = "0.7.13"
 ForwardDiff = "0.10, 1"
 LinearAlgebra = "1.10"
+LogExpFunctions = "0.3.28 - 0.3"
 OptimizationBase = "5"
 Pkg = "1"
 Reexport = "1.2"
 SafeTestsets = "0.1"
 SciMLBase = "2.122.1, 3"
-SimpleNonlinearSolve = "1, 2"
+SimpleNonlinearSolve = "2"
 Test = "1.10"
 julia = "1.10"
 
 [targets]
-test = ["Test", "ForwardDiff", "SafeTestsets", "Pkg"]
+test = ["Test", "ForwardDiff", "SafeTestsets", "Pkg", "LogExpFunctions", "DifferentiationInterface"]

--- a/lib/SimpleOptimization/src/SimpleOptimization.jl
+++ b/lib/SimpleOptimization/src/SimpleOptimization.jl
@@ -187,7 +187,7 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: SimpleLBFGS}
         nlprob,
         SimpleLimitedMemoryBroyden(;
             threshold = __get_threshold(cache.opt),
-            linesearch = nothing
+            linesearch = Val(false)
         );
         maxiters = maxiters,
         abstol = abstol,
@@ -228,7 +228,7 @@ function SciMLBase.__solve(cache::OptimizationCache{O}) where {O <: SimpleBFGS}
     nlprob = NonlinearProblem(∇f, cache.u0)
     nlsol = solve(
         nlprob,
-        SimpleBroyden(; linesearch = nothing);
+        SimpleBroyden(; linesearch = Val(false));
         maxiters = maxiters,
         abstol = abstol,
         reltol = reltol


### PR DESCRIPTION
## Summary

This draft PR fixes the current Downgrade Sublibraries failures for the shared OptimizationBase/SparseConnectivityTracer lower-bound path and the SimpleOptimization lower-bound path.

Ignore this PR until reviewed by @ChrisRackauckas.

Changes:
- Raise `OptimizationBase` lower bounds for `ADTypes` and `SparseConnectivityTracer` to versions compatible with the current dependency stack.
- Add test-only `LogExpFunctions` compat to affected sublibraries so downgraded test manifests choose the `0.3.28 - 0.3` range required by `SparseConnectivityTracer` 1.x.
- Update `SimpleOptimization` lower bounds and pass `Val(false)` for Broyden `linesearch`, matching `SimpleNonlinearSolve` 2.x constructors.

## Local verification

All commands used `timeout 3600`, Julia 1.10, a local depot, and `Pkg.test(...; allow_reresolve=false)` after local downgrade-manifest generation.

Passed:
- `lib/OptimizationBBO`: `Core | Pass 25 Total 25`
- `lib/OptimizationEvolutionary`: `Core | Pass 32 Total 32`
- `lib/OptimizationNOMAD`: `Core | Pass 4 Total 4`
- `lib/OptimizationSciPy`: `Core | Pass 160 Broken 1 Total 161`
- `lib/SimpleOptimization`: `Core | Pass 7 Total 7`
- `Runic --check lib/SimpleOptimization/src/SimpleOptimization.jl`
- `git diff --cached --check`

Remaining separate failures observed and intentionally not fixed here:
- `lib/OptimizationNLPModels`: after downgrade resolution, `Pkg.test(... allow_reresolve=false)` still hits a SciML stack manifest conflict involving `DiffEqBase`, `SciMLBase`, `ModelingToolkitBase`, `FastBroadcast`, and `RecursiveArrayTools`.
- `lib/OptimizationQuadDIRECT`: downgrade generation does not add URL `[sources]` package `QuadDIRECT` to the generated manifest, so `Pkg.test` errors that `QuadDIRECT` is a direct dependency missing from the manifest.
