### PR TITLE
Remove stale OptimizationMOI MTK imports

### DIFF
--- a/lib/OptimizationMOI/src/OptimizationMOI.jl
+++ b/lib/OptimizationMOI/src/OptimizationMOI.jl
@@ -7,7 +7,6 @@ using SciMLBase
 using SciMLStructures
 using SymbolicIndexingInterface
 using SparseArrays
-import ModelingToolkitBase: parameters, unknowns, varmap_to_vars, mergedefaults, toexpr
 import ModelingToolkitBase
 const MTK = ModelingToolkitBase
 using Symbolics


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- remove stale direct imports from `ModelingToolkitBase` in `OptimizationMOI`
- keep using the existing `MTK = ModelingToolkitBase` alias for public access
- avoids Julia 1.13 precompile output warning that `ModelingToolkitBase.mergedefaults` is undeclared at import time

## Verification
- On clean `master`, `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.13 --project=lib/OptimizationMOI -e 'using Pkg; Pkg.instantiate(); Pkg.precompile(); using OptimizationMOI; println("OptimizationMOI loaded")'` loaded but emitted `WARNING: Imported binding ModelingToolkitBase.mergedefaults was undeclared at import time during import to OptimizationMOI.`
- After this patch, the same Julia 1.13 command passed with `OptimizationMOI loaded` and no `ModelingToolkitBase.mergedefaults` undeclared-import warning.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.13 --project=lib/OptimizationMOI -e 'using Pkg; Pkg.test(; julia_args=["--check-bounds=yes", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false)'`: passed, `Core | 40 pass, 2 broken, 42 total`.
