### PR TITLE
Avoid non-public promote_op in OptimizationBase

### DIFF
--- a/lib/OptimizationBase/src/OptimizationDIExt.jl
+++ b/lib/OptimizationBase/src/OptimizationDIExt.jl
@@ -23,8 +23,8 @@ using OptimizationBase.FastClosures
 @inline _prep_valid(::Type{T}, v) where {T} = typeof(v) === T
 
 # Output-buffer eltype for the `p`-accepting constraint wrapper: the type `f.cons` produces,
-# including the *nested* dual when both `x` (DI's seeds) and `p` (the sensitivity layer) carry
-# duals with different tags (`promote_op(+, …)` nests them). Deliberately uses plain `eltype(p)`
+# including nested duals when both `x` (DI's seeds) and `p` (the sensitivity layer) carry
+# duals. Deliberately uses plain `eltype(p)`
 # rather than `SciMLBase.anyeltypedual`: this runs *inside* the DI-differentiated wrapper, and
 # Enzyme's forward mode corrupts the derivative shadow (DataType-valued entries) when the
 # allocation type flows through `anyeltypedual` — in either its value or its type-level form,
@@ -32,11 +32,18 @@ using OptimizationBase.FastClosures
 # eltype) therefore falls back to `eltype(x)`; duals nested inside such a `p` are the one
 # unsupported case. (`_prep_valid` above runs in the outer closure, outside anything a backend
 # differentiates, so its type comparison is safe there.)
+@inline function _add_output_eltype(::Type{Tu}, ::Type{Tp}) where {Tu, Tp}
+    return try
+        typeof(zero(Tu) + zero(Tp))
+    catch
+        Any
+    end
+end
 @inline function _cons_out_eltype(x, p)
     Tu = eltype(x)
     p isa Union{SciMLBase.NullParameters, Nothing} && return Tu
     Tp = eltype(p)
-    return Tp <: Number ? Base.promote_op(+, Tu, Tp) : Tu
+    return Tp <: Number ? _add_output_eltype(Tu, Tp) : Tu
 end
 
 function instantiate_function(


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Replace the `Base.promote_op` dependency in `OptimizationDIExt.jl` with a local public-API output-eltype helper.
- Keep the `p`-accepting constraint Jacobian output buffer usable for dual and numeric parameter eltypes.

## Root cause
OptimizationBase QA on master failed `ExplicitImports.all_qualified_accesses_are_public` because `Base.promote_op` is not public API.

## Verification
Reproduced on the pre-fix base (`59bdb75fe`):
- `OPTIMIZATION_TEST_GROUP=QA julia --project=lib/OptimizationBase -e 'import Pkg; Pkg.test()'`
- Result: `NonPublicQualifiedAccessException`: `promote_op` is not public in `Base`; summary `16 passed, 1 errored, 1 broken`.

Verified on this rebased branch (`5cb560a08940f5592cd79b1654544afc6961d2f1`):
- `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_165240_11300/Optimization.jl/.julia-depot OPTIMIZATION_TEST_GROUP=QA julia --startup-file=no --project=lib/OptimizationBase -e 'import Pkg; Pkg.test(; coverage=false, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'`
  - Result: `Quality Assurance | 17 pass, 1 broken, 18 total`; `Testing OptimizationBase tests passed`.
- `timeout 3600 env JULIA_DEPOT_PATH=/home/crackauc/sandbox/tmp_20260708_165240_11300/.julia-depot julia --startup-file=no --project=/home/crackauc/sandbox/tmp_20260708_165240_11300/.runic-env -m Runic --check lib/OptimizationBase/src/OptimizationDIExt.jl`
  - Result: passed.
- `git diff --check origin/master..HEAD`
  - Result: passed with no output.
