### PR TITLE
Bump version to 5.6.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Optimization"
 uuid = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
-version = "5.6.3"
+version = "5.6.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Automated patch version bump (5.6.3 -> 5.6.4) to release unreleased commits on `master` via JuliaRegistrator.