### PR TITLE
ci: use targeted monorepo TagBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -3,42 +3,28 @@ on:
   issue_comment:
     types: [created]
   workflow_dispatch:
+    inputs:
+      package:
+        description: "Package name to tag; empty audits every package"
+        required: false
+        type: string
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
 jobs:
   tagbot:
-    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
-    secrets: "inherit"
-  tagbot-subpackages:
-    strategy:
-      fail-fast: false
-      matrix:
-        subdir:
-          - "lib/OptimizationAuglag"
-          - "lib/OptimizationBBO"
-          - "lib/OptimizationBase"
-          - "lib/OptimizationCMAEvolutionStrategy"
-          - "lib/OptimizationEvolutionary"
-          - "lib/OptimizationGCMAES"
-          - "lib/OptimizationIpopt"
-          - "lib/OptimizationLBFGSB"
-          - "lib/OptimizationMOI"
-          - "lib/OptimizationMadNLP"
-          - "lib/OptimizationManopt"
-          - "lib/OptimizationMetaheuristics"
-          - "lib/OptimizationMultistartOptimization"
-          - "lib/OptimizationNLPModels"
-          - "lib/OptimizationNLopt"
-          - "lib/OptimizationNOMAD"
-          - "lib/OptimizationODE"
-          - "lib/OptimizationOptimJL"
-          - "lib/OptimizationOptimisers"
-          - "lib/OptimizationPRIMA"
-          - "lib/OptimizationPolyalgorithms"
-          - "lib/OptimizationPyCMA"
-          - "lib/OptimizationSciPy"
-          - "lib/OptimizationSophia"
-          - "lib/OptimizationSpeedMapping"
-          - "lib/SimpleOptimization"
-    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    uses: "SciML/.github/.github/workflows/monorepo-tagbot.yml@v1"
     with:
-      subdir: "${{ matrix.subdir }}"
+      package: "${{ inputs.package }}"
     secrets: "inherit"


### PR DESCRIPTION
## Summary\n\nReplace the root-plus-sublibrary TagBot matrix with the shared targeted monorepo workflow from SciML/.github.\n\nJuliaTagBot registration comments are resolved to the single registered package, so each registration runs one TagBot invocation instead of auditing every package. Manual runs retain an optional package input; empty retries remain serialized full audits.\n\nThe caller keeps the explicit repository permissions required by the reusable workflow and inherits the existing secrets.\n\n## Validation\n\n- actionlint passed\n- Ruby YAML parsing passed\n- git diff --check passed\n\n> Ignore this PR until reviewed by @ChrisRackauckas.