### PR TITLE
Fix OptimizationManopt reporting MaxIters even when converged

### DIFF
--- a/docs/src/optimization_packages/manopt.md
+++ b/docs/src/optimization_packages/manopt.md
@@ -52,10 +52,16 @@ opt = OptimizationManopt.GradientDescentOptimizer()
 optf = OptimizationFunction(rosenbrock, ADTypes.AutoZygote())
 
 prob = OptimizationProblem(
-    optf, x0, p; manifold = R2, stepsize = stepsize)
+    optf, x0, p; manifold = R2, stepsize = stepsize, maxiters = 25000)
 
 sol = Optimization.solve(prob, opt)
 ```
+
+!!! note
+
+    Plain gradient descent zig-zags slowly down Rosenbrock's narrow curved valley, so it
+    needs tens of thousands of iterations (still well under a second here) to bring the
+    gradient norm below the default tolerance and report `retcode = Success`.
 
 The box-constrained Karcher mean problem on the SPD manifold with the Frank-Wolfe algorithm can be solved as follows:
 
@@ -90,10 +96,12 @@ U = mean(data2)
 L = inv(sum(1 / N * inv(matrix) for matrix in data2))
 
 optf = OptimizationFunction(f, ADTypes.AutoZygote())
-prob = OptimizationProblem(optf, U; manifold = M, maxiters = 1000)
+prob = OptimizationProblem(optf, U; manifold = M, maxiters = 5000)
 
+opt = OptimizationManopt.FrankWolfeOptimizer()
 sol = Optimization.solve(
-    prob, opt, sub_problem = (M, q, p, X) -> closed_form_solution!(M, q, L, U, p, X))
+    prob, opt, sub_problem = (M, q, p, X) -> closed_form_solution!(M, q, L, U, p, X),
+    evaluation = Manopt.InplaceEvaluation())
 ```
 
 This example is based on the [example](https://juliamanifolds.github.io/ManoptExamples.jl/stable/examples/Riemannian-mean/) in the Manopt and [Weber and Sra'22](https://doi.org/10.1007/s10107-022-01840-5).
@@ -115,7 +123,7 @@ egrad(G, x, p = nothing) = (G .= -2 * A * x)
 
 optf = OptimizationFunction(cost, grad = egrad)
 x0 = rand(manifold)
-prob = OptimizationProblem(optf, x0, manifold = manifold)
+prob = OptimizationProblem(optf, x0, manifold = manifold, maxiters = 5000)
 
 sol = solve(prob, GradientDescentOptimizer())
 ```

--- a/docs/src/optimization_packages/manopt.md
+++ b/docs/src/optimization_packages/manopt.md
@@ -91,10 +91,16 @@ opt = OptimizationManopt.GradientDescentOptimizer()
 optf = OptimizationFunction(rosenbrock, ADTypes.AutoZygote())
 
 prob = OptimizationProblem(
-    optf, x0, p; manifold = R2, stepsize = stepsize)
+    optf, x0, p; manifold = R2, stepsize = stepsize, maxiters = 25000)
 
 sol = OptimizationBase.solve(prob, opt)
 ```
+
+!!! note
+
+    Plain gradient descent zig-zags slowly down Rosenbrock's narrow curved valley, so it
+    needs tens of thousands of iterations (still well under a second here) to bring the
+    gradient norm below the default tolerance and report `retcode = Success`.
 
 The box-constrained Karcher mean problem on the SPD manifold with the Frank-Wolfe algorithm can be solved as follows:
 
@@ -129,10 +135,12 @@ U = mean(data2)
 L = inv(sum(1 / N * inv(matrix) for matrix in data2))
 
 optf = OptimizationFunction(f, ADTypes.AutoZygote())
-prob = OptimizationProblem(optf, U; manifold = M, maxiters = 1000)
+prob = OptimizationProblem(optf, U; manifold = M, maxiters = 5000)
 
+opt = OptimizationManopt.FrankWolfeOptimizer()
 sol = OptimizationBase.solve(
-    prob, opt, sub_problem = (M, q, p, X) -> closed_form_solution!(M, q, L, U, p, X))
+    prob, opt, sub_problem = (M, q, p, X) -> closed_form_solution!(M, q, L, U, p, X),
+    evaluation = Manopt.InplaceEvaluation())
 ```
 
 This example is based on the [example](https://juliamanifolds.github.io/ManoptExamples.jl/stable/examples/Riemannian-mean/) in the Manopt and [Weber and Sra'22](https://doi.org/10.1007/s10107-022-01840-5).
@@ -154,7 +162,7 @@ egrad(G, x, p = nothing) = (G .= -2 * A * x)
 
 optf = OptimizationFunction(cost, grad = egrad)
 x0 = rand(manifold)
-prob = OptimizationProblem(optf, x0, manifold = manifold)
+prob = OptimizationProblem(optf, x0, manifold = manifold, maxiters = 5000)
 
 sol = solve(prob, GradientDescentOptimizer())
 ```

--- a/docs/src/optimization_packages/manopt.md
+++ b/docs/src/optimization_packages/manopt.md
@@ -46,6 +46,15 @@ OptimizationManopt.TrustRegionsOptimizer
 The common kwargs `maxiters`, `maxtime` and `abstol` are supported by all the optimizers. Solver specific kwargs from Manopt can be passed to the `solve`
 function or `OptimizationProblem`.
 
+Passing `maxiters`/`maxtime` bounds the run while keeping the convergence part of the
+solver's own Manopt default stopping criterion active, so a run that converges before
+hitting the bound reports `retcode = Success` rather than `MaxIters`/`MaxTime`. For the
+derivative-free solvers (`NelderMeadOptimizer`, `ParticleSwarmOptimizer`, `CMAESOptimizer`)
+and `ConvexBundleOptimizer`, Manopt's own stopping criteria never indicate convergence, so
+a run bounded only by `maxiters`/`maxtime` reports `MaxIters`/`MaxTime`. A Manopt
+`stopping_criterion` passed as a solver kwarg is combined with the requested
+`maxiters`/`maxtime` bounds and replaces the default convergence criterion.
+
 !!! note
 
     The `OptimizationProblem` has to be passed the manifold as the `manifold` keyword argument.
@@ -99,8 +108,8 @@ sol = OptimizationBase.solve(prob, opt)
 !!! note
 
     Plain gradient descent zig-zags slowly down Rosenbrock's narrow curved valley, so it
-    needs tens of thousands of iterations (still well under a second here) to bring the
-    gradient norm below the default tolerance and report `retcode = Success`.
+    needs tens of thousands of iterations (a few seconds here) to bring the gradient norm
+    below the default tolerance and report `retcode = Success`.
 
 The box-constrained Karcher mean problem on the SPD manifold with the Frank-Wolfe algorithm can be solved as follows:
 
@@ -112,8 +121,6 @@ q = Matrix{Float64}(I, 5, 5) .+ 2.0
 data2 = [exp(M, q, σ * rand(M; vector_at = q)) for i in 1:m]
 
 f(x, p = nothing) = sum(distance(M, x, data2[i])^2 for i in 1:m)
-optf = OptimizationFunction(f, ADTypes.AutoZygote())
-prob = OptimizationProblem(optf, data2[1]; manifold = M, maxiters = 1000)
 
 function closed_form_solution!(M::SymmetricPositiveDefinite, q, L, U, p, X)
     # extract p^1/2 and p^{-1/2}

--- a/lib/OptimizationManopt/src/OptimizationManopt.jl
+++ b/lib/OptimizationManopt/src/OptimizationManopt.jl
@@ -44,6 +44,19 @@ function __map_optimizer_args!(
 
     if !isnothing(abstol)
         push!(criteria, _default_convergence_criterion(opt, manifold, abstol))
+    elseif !isnothing(maxiters) || !isnothing(maxtime)
+        # Without this, `criteria` above would contain *only* `StopAfterIteration`/
+        # `StopAfter`, which never `indicates_convergence` (Manopt.jl semantics), so
+        # `Manopt.has_converged` could never be true and the run would always report
+        # `ReturnCode.MaxIters`/`MaxTime` below, no matter how well it actually converged.
+        # Falling back to each solver's own default tolerance (rather than one constant)
+        # keeps this close to what Manopt would have done with no `stopping_criterion`
+        # override at all; optimizers whose real default isn't a single tolerance-based
+        # criterion opt out via `_default_fallback_abstol` returning `nothing`.
+        fallback_abstol = _default_fallback_abstol(opt)
+        if !isnothing(fallback_abstol)
+            push!(criteria, _default_convergence_criterion(opt, manifold, fallback_abstol))
+        end
     end
 
     if !isnothing(reltol)
@@ -283,6 +296,24 @@ end
 function _default_convergence_criterion(::AbstractManoptOptimizer, M, abstol)
     return Manopt.StopWhenChangeLess(M, abstol)
 end
+
+# Fallback tolerance used, via `_default_convergence_criterion` above, only when the user
+# supplies `maxiters`/`maxtime` without an explicit `abstol` (see `__map_optimizer_args!`).
+# Each value mirrors that solver's own top-level default tolerance in Manopt.jl, so this
+# stays close to "what Manopt would have done with no override at all" instead of imposing
+# one generic number. Optimizers whose real Manopt default is a composite criterion that
+# isn't representable as a single `_default_convergence_criterion` call (`NelderMead`'s
+# `StopWhenPopulationConcentrated`, `CMAES`'s multi-part `default_cma_es_stopping_criterion`,
+# `ConvexBundle`'s `StopWhenLagrangeMultiplierLess`, not gradient-norm) opt out with
+# `nothing`, leaving their pre-existing behavior unchanged.
+_default_fallback_abstol(::GradientDescentOptimizer) = 1.0e-8
+_default_fallback_abstol(::ConjugateGradientDescentOptimizer) = 1.0e-8
+_default_fallback_abstol(::QuasiNewtonOptimizer) = 1.0e-6
+_default_fallback_abstol(::TrustRegionsOptimizer) = 1.0e-6
+_default_fallback_abstol(::AdaptiveRegularizationCubicOptimizer) = 1.0e-9
+_default_fallback_abstol(::FrankWolfeOptimizer) = 1.0e-6
+_default_fallback_abstol(::ParticleSwarmOptimizer) = 1.0e-4
+_default_fallback_abstol(::AbstractManoptOptimizer) = nothing
 
 function build_loss(f::OptimizationBase.OptimizationFunction, prob, cb)
     # TODO: I do not understand this. Why is the manifold not used?

--- a/lib/OptimizationManopt/src/OptimizationManopt.jl
+++ b/lib/OptimizationManopt/src/OptimizationManopt.jl
@@ -29,6 +29,7 @@ function __map_optimizer_args!(
         maxtime::Union{Number, Nothing} = nothing,
         abstol::Union{Number, Nothing} = nothing,
         reltol::Union{Number, Nothing} = nothing,
+        stopping_criterion::Union{Manopt.StoppingCriterion, Nothing} = nothing,
         kwargs...
     )
     criteria = Manopt.StoppingCriterion[]
@@ -41,20 +42,28 @@ function __map_optimizer_args!(
         push!(criteria, Manopt.StopAfter(Millisecond(round(Int, maxtime * 1000))))
     end
 
+    if !isnothing(stopping_criterion)
+        # A Manopt `stopping_criterion` passed by the user is combined with the other
+        # explicitly requested criteria (`maxiters`/`maxtime`/`abstol`) rather than
+        # silently replaced by them, and it suppresses the convergence fallback below.
+        push!(criteria, stopping_criterion)
+    end
+
     if !isnothing(abstol)
         push!(criteria, _default_convergence_criterion(opt, manifold, abstol))
-    elseif !isnothing(maxiters) || !isnothing(maxtime)
+    elseif isnothing(stopping_criterion) && (!isnothing(maxiters) || !isnothing(maxtime))
         # Without this, `criteria` above would contain *only* `StopAfterIteration`/
         # `StopAfter`, which never `indicates_convergence` (Manopt.jl semantics), so
         # `Manopt.has_converged` could never be true and the run would always report
         # `ReturnCode.MaxIters`/`MaxTime` below, no matter how well it actually converged.
-        # Falling back to each solver's own default tolerance (rather than one constant)
-        # keeps this close to what Manopt would have done with no `stopping_criterion`
-        # override at all; optimizers whose real default isn't a single tolerance-based
-        # criterion opt out via `_default_fallback_abstol` returning `nothing`.
-        fallback_abstol = _default_fallback_abstol(opt)
-        if !isnothing(fallback_abstol)
-            push!(criteria, _default_convergence_criterion(opt, manifold, fallback_abstol))
+        # Re-adding the convergence part of the solver's own Manopt default keeps the run
+        # behaving as if `maxiters`/`maxtime` merely tightened the default criterion
+        # instead of discarding it; solvers whose Manopt default cannot indicate
+        # convergence opt out via `_manopt_default_convergence_criterion` returning
+        # `nothing` (see the comment there).
+        fallback = _manopt_default_convergence_criterion(opt, manifold)
+        if !isnothing(fallback)
+            push!(criteria, fallback)
         end
     end
 
@@ -348,23 +357,45 @@ function _default_convergence_criterion(::AbstractManoptOptimizer, M, abstol)
     return Manopt.StopWhenChangeLess(M, abstol)
 end
 
-# Fallback tolerance used, via `_default_convergence_criterion` above, only when the user
-# supplies `maxiters`/`maxtime` without an explicit `abstol` (see `__map_optimizer_args!`).
-# Each value mirrors that solver's own top-level default tolerance in Manopt.jl, so this
-# stays close to "what Manopt would have done with no override at all" instead of imposing
-# one generic number. Optimizers whose real Manopt default is a composite criterion that
-# isn't representable as a single `_default_convergence_criterion` call (`NelderMead`'s
-# `StopWhenPopulationConcentrated`, `CMAES`'s multi-part `default_cma_es_stopping_criterion`,
-# `ConvexBundle`'s `StopWhenLagrangeMultiplierLess`, not gradient-norm) opt out with
-# `nothing`, leaving their pre-existing behavior unchanged.
-_default_fallback_abstol(::GradientDescentOptimizer) = 1.0e-8
-_default_fallback_abstol(::ConjugateGradientDescentOptimizer) = 1.0e-8
-_default_fallback_abstol(::QuasiNewtonOptimizer) = 1.0e-6
-_default_fallback_abstol(::TrustRegionsOptimizer) = 1.0e-6
-_default_fallback_abstol(::AdaptiveRegularizationCubicOptimizer) = 1.0e-9
-_default_fallback_abstol(::FrankWolfeOptimizer) = 1.0e-6
-_default_fallback_abstol(::ParticleSwarmOptimizer) = 1.0e-4
-_default_fallback_abstol(::AbstractManoptOptimizer) = nothing
+# Convergence criterion injected alongside `StopAfterIteration`/`StopAfter` only when the
+# user supplies `maxiters`/`maxtime` without an explicit `abstol` or `stopping_criterion`
+# (see `__map_optimizer_args!`). Each method mirrors, verbatim, the convergence part of the
+# corresponding high-level Manopt solver's default `stopping_criterion` (checked against
+# Manopt 0.5.25 and 0.6.6), so `maxiters`/`maxtime` behaves as if it merely retuned the
+# iteration/time part of Manopt's default instead of discarding the whole thing.
+#
+# The remaining solvers return `nothing` and keep the pre-existing behavior (a
+# `maxiters`-only run reports `ReturnCode.MaxIters`): the convergence-ish criteria in their
+# Manopt defaults — `ParticleSwarm`'s `StopWhenSwarmVelocityLess`, `NelderMead`'s
+# `StopWhenPopulationConcentrated`, `ConvexBundle`'s `StopWhenLagrangeMultiplierLess`, and
+# parts of `CMAES`'s `default_cma_es_stopping_criterion` — all have
+# `Manopt.indicates_convergence(...) == false`, so injecting them could never yield
+# `ReturnCode.Success`; it would only cut the run short and turn `MaxIters` into `Failure`.
+function _manopt_default_convergence_criterion(::GradientDescentOptimizer, M)
+    return Manopt.StopWhenGradientNormLess(1.0e-8)
+end
+function _manopt_default_convergence_criterion(::ConjugateGradientDescentOptimizer, M)
+    return Manopt.StopWhenGradientNormLess(1.0e-8)
+end
+function _manopt_default_convergence_criterion(::QuasiNewtonOptimizer, M)
+    return Manopt.StopWhenGradientNormLess(1.0e-6)
+end
+function _manopt_default_convergence_criterion(::TrustRegionsOptimizer, M)
+    return Manopt.StopWhenGradientNormLess(1.0e-6)
+end
+function _manopt_default_convergence_criterion(::AdaptiveRegularizationCubicOptimizer, M)
+    # Manopt's default also contains `StopWhenAllLanczosVectorsUsed`, a safeguard rather
+    # than a convergence test; it is not constructible independently of the sub-state, and
+    # the always-present `StopAfterIteration` bounds the run in its stead.
+    return Manopt.StopWhenGradientNormLess(1.0e-9)
+end
+function _manopt_default_convergence_criterion(::FrankWolfeOptimizer, M)
+    # Frank-Wolfe solves constrained problems, where the gradient norm alone need not
+    # vanish at a boundary optimum; Manopt's default therefore also stops on the change
+    # between iterates, and dropping that half would leave such runs on `MaxIters`.
+    return Manopt.StopWhenGradientNormLess(1.0e-8) | Manopt.StopWhenChangeLess(M, 1.0e-8)
+end
+_manopt_default_convergence_criterion(::AbstractManoptOptimizer, M) = nothing
 
 function build_loss(f::OptimizationBase.OptimizationFunction, prob, cb)
     # TODO: I do not understand this. Why is the manifold not used?
@@ -468,6 +499,11 @@ function SciMLBase.__solve(cache::OptimizationBase.OptimizationCache{O}) where {
     asc = get_stopping_criterion(opt_res.options)
     active = Manopt.get_active_stopping_criteria(asc)
     opt_ret = if Manopt.has_converged(asc)
+        ReturnCode.Success
+    elseif any(c -> c isa Manopt.StopWhenChangeLess, active)
+        # `indicates_convergence(StopWhenChangeLess)` is `false` in Manopt 0.5 but `true`
+        # in Manopt 0.6 (where `has_converged` above already yields `Success`); map it
+        # explicitly so the retcode does not depend on the Manopt version.
         ReturnCode.Success
     elseif any(c -> c isa Manopt.StopAfterIteration, active)
         ReturnCode.MaxIters

--- a/lib/OptimizationManopt/src/OptimizationManopt.jl
+++ b/lib/OptimizationManopt/src/OptimizationManopt.jl
@@ -43,6 +43,19 @@ function __map_optimizer_args!(
 
     if !isnothing(abstol)
         push!(criteria, _default_convergence_criterion(opt, manifold, abstol))
+    elseif !isnothing(maxiters) || !isnothing(maxtime)
+        # Without this, `criteria` above would contain *only* `StopAfterIteration`/
+        # `StopAfter`, which never `indicates_convergence` (Manopt.jl semantics), so
+        # `Manopt.has_converged` could never be true and the run would always report
+        # `ReturnCode.MaxIters`/`MaxTime` below, no matter how well it actually converged.
+        # Falling back to each solver's own default tolerance (rather than one constant)
+        # keeps this close to what Manopt would have done with no `stopping_criterion`
+        # override at all; optimizers whose real default isn't a single tolerance-based
+        # criterion opt out via `_default_fallback_abstol` returning `nothing`.
+        fallback_abstol = _default_fallback_abstol(opt)
+        if !isnothing(fallback_abstol)
+            push!(criteria, _default_convergence_criterion(opt, manifold, fallback_abstol))
+        end
     end
 
     if !isnothing(reltol)
@@ -334,6 +347,24 @@ end
 function _default_convergence_criterion(::AbstractManoptOptimizer, M, abstol)
     return Manopt.StopWhenChangeLess(M, abstol)
 end
+
+# Fallback tolerance used, via `_default_convergence_criterion` above, only when the user
+# supplies `maxiters`/`maxtime` without an explicit `abstol` (see `__map_optimizer_args!`).
+# Each value mirrors that solver's own top-level default tolerance in Manopt.jl, so this
+# stays close to "what Manopt would have done with no override at all" instead of imposing
+# one generic number. Optimizers whose real Manopt default is a composite criterion that
+# isn't representable as a single `_default_convergence_criterion` call (`NelderMead`'s
+# `StopWhenPopulationConcentrated`, `CMAES`'s multi-part `default_cma_es_stopping_criterion`,
+# `ConvexBundle`'s `StopWhenLagrangeMultiplierLess`, not gradient-norm) opt out with
+# `nothing`, leaving their pre-existing behavior unchanged.
+_default_fallback_abstol(::GradientDescentOptimizer) = 1.0e-8
+_default_fallback_abstol(::ConjugateGradientDescentOptimizer) = 1.0e-8
+_default_fallback_abstol(::QuasiNewtonOptimizer) = 1.0e-6
+_default_fallback_abstol(::TrustRegionsOptimizer) = 1.0e-6
+_default_fallback_abstol(::AdaptiveRegularizationCubicOptimizer) = 1.0e-9
+_default_fallback_abstol(::FrankWolfeOptimizer) = 1.0e-6
+_default_fallback_abstol(::ParticleSwarmOptimizer) = 1.0e-4
+_default_fallback_abstol(::AbstractManoptOptimizer) = nothing
 
 function build_loss(f::OptimizationBase.OptimizationFunction, prob, cb)
     # TODO: I do not understand this. Why is the manifold not used?

--- a/lib/OptimizationManopt/test/core_tests.jl
+++ b/lib/OptimizationManopt/test/core_tests.jl
@@ -51,6 +51,28 @@ R2 = Euclidean(2)
         @test sol.objective < 0.2
     end
 
+    @testset "Gradient descent maxiters without abstol still reports Success" begin
+        # Regression test: passing only `maxiters` (no `abstol`) used to fully replace
+        # Manopt's own default `stopping_criterion`, leaving `StopAfterIteration` as the
+        # *only* criterion. Since that criterion never `indicates_convergence`, the run
+        # was structurally guaranteed to report `ReturnCode.MaxIters`, even once it had
+        # actually converged. `maxiters` here is set well above what's needed so the run
+        # converges before hitting the cap.
+        x0 = zeros(2)
+        p = [1.0, 100.0]
+
+        stepsize = Manopt.ArmijoLinesearch(R2)
+        opt = OptimizationManopt.GradientDescentOptimizer()
+
+        optprob = OptimizationFunction(rosenbrock, OptimizationBase.AutoForwardDiff())
+        prob = OptimizationProblem(
+            optprob, x0, p; manifold = R2, stepsize = stepsize, maxiters = 25_000
+        )
+        sol = OptimizationBase.solve(prob, opt)
+        @test sol.objective < 1.0e-10
+        @test SciMLBase.successful_retcode(sol)
+    end
+
     @testset "Nelder-Mead" begin
         x0 = zeros(2)
         p = [1.0, 100.0]

--- a/lib/OptimizationManopt/test/core_tests.jl
+++ b/lib/OptimizationManopt/test/core_tests.jl
@@ -73,6 +73,28 @@ R2 = Euclidean(2)
         @test SciMLBase.successful_retcode(sol)
     end
 
+    @testset "User-supplied stopping_criterion is combined, not clobbered" begin
+        # Regression test: a Manopt `stopping_criterion` passed through `solve` used to be
+        # silently overwritten whenever `maxiters`/`maxtime`/`abstol` was also given.
+        x0 = zeros(2)
+        p = [1.0, 100.0]
+
+        stepsize = Manopt.ArmijoLinesearch(R2)
+        opt = OptimizationManopt.GradientDescentOptimizer()
+
+        optprob = OptimizationFunction(rosenbrock, OptimizationBase.AutoForwardDiff())
+        prob = OptimizationProblem(
+            optprob, x0, p; manifold = R2, stepsize = stepsize, maxiters = 25_000
+        )
+        user_sc = Manopt.StopWhenGradientNormLess(1.0e-3)
+        sol = OptimizationBase.solve(prob, opt; stopping_criterion = user_sc)
+        sc = Manopt.get_stopping_criterion(sol.original)
+        @test any(c -> c === user_sc, sc.criteria)
+        # The user's criterion also suppresses the (tighter) 1e-8 default fallback.
+        @test !any(c -> c isa Manopt.StopWhenGradientNormLess && c !== user_sc, sc.criteria)
+        @test SciMLBase.successful_retcode(sol)
+    end
+
     @testset "Nelder-Mead" begin
         x0 = zeros(2)
         p = [1.0, 100.0]
@@ -114,7 +136,11 @@ R2 = Euclidean(2)
         prob = OptimizationProblem(optprob, x0, p; manifold = R2)
 
         sol = OptimizationBase.solve(prob, opt, callback = callback, maxiters = 30)
-        @test sol.objective < 1.0e-14
+        # With `maxiters` given, Manopt's default `StopWhenGradientNormLess(1e-6)` stays
+        # active, so the run stops (converged) slightly earlier than the old
+        # `StopAfterIteration`-only criterion, which ran the budget down to < 1e-14.
+        @test sol.objective < 1.0e-12
+        @test SciMLBase.successful_retcode(sol)
     end
 
     @testset "Particle swarm" begin
@@ -128,6 +154,13 @@ R2 = Euclidean(2)
 
         sol = OptimizationBase.solve(prob, opt)
         @test sol.objective < 0.1
+
+        # Manopt's own PSO convergence test (`StopWhenSwarmVelocityLess`) never
+        # `indicates_convergence`, so no fallback criterion is injected for PSO and a
+        # `maxiters`-bounded run keeps reporting `MaxIters` instead of stopping early on
+        # some unrelated criterion and reporting `Failure`/spurious `Success`.
+        sol = OptimizationBase.solve(prob, opt; maxiters = 100)
+        @test sol.retcode == SciMLBase.ReturnCode.MaxIters
     end
 
     @testset "CMA-ES" begin


### PR DESCRIPTION
## Problem

Passing `maxiters`/`maxtime` replaced Manopt's whole default `stopping_criterion` with just `StopAfterIteration`/`StopAfter`. Those never indicate convergence in Manopt's semantics, so such runs always reported `ReturnCode.MaxIters`, even when they had converged. Fixes the underlying issue behind #1034 (which #1169 exposed but didn't resolve).

## Fix

`maxiters`/`maxtime` now only retunes the iteration/time part of Manopt's default criterion, keeping its convergence part active:

- The re-added convergence criteria mirror each solver's Manopt default verbatim (verified against Manopt 0.5.25 and 0.6.6), e.g. `StopWhenGradientNormLess(1e-8)` for gradient descent, or the full composite `StopWhenGradientNormLess(1e-8) | StopWhenChangeLess(M, 1e-8)` for Frank-Wolfe — the change half is what fires at constrained boundary optima.
- ParticleSwarm, NelderMead, CMAES, and ConvexBundle are excluded: their Manopt default criteria have `indicates_convergence == false`, so injecting them could never yield `Success` — it would only cut runs short. They keep reporting `MaxIters`.
- A user-supplied Manopt `stopping_criterion` is now combined with `maxiters`/`maxtime` instead of silently clobbered, and it suppresses the fallback.
- `StopWhenChangeLess` stops map to `Success` explicitly, since Manopt 0.5 and 0.6 disagree on whether it indicates convergence.

**Behavioral note:** a `maxiters`-only run can now stop early once the solver's default tolerance is met — same semantics as the other wrappers (e.g. Optim). A fixed-iteration budget is still expressible via an explicit `stopping_criterion`. The pre-existing Quasi-Newton test was updated for this (converges at ~1.3e-14 just before its 30-iteration budget).

## Docs

- Karcher-mean example actually runs Frank-Wolfe now (`opt` was never reassigned, so Manopt dropped the unrecognized `sub_problem` kwarg and ran gradient descent); removed a stale duplicate problem construction and adapted to the Manopt 0.6 `sub_problem` convention.
- Documented the `maxiters`/`maxtime` retcode semantics. All three examples report `retcode = Success`, verified end-to-end on Manopt 0.6.6.

## Test plan

- [x] `Pkg.test()` Core group on latest Manopt (0.6.6) — 21/21 pass
- [x] Regression tests: `maxiters`-only GD reports `Success`; PSO keeps `MaxIters`; user `stopping_criterion` is kept and suppresses the fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)