### PR TITLE
Fix NeuralPDE downstream groups

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -13,7 +13,8 @@ jobs:
       matrix:
         package:
           - {user: SciML, repo: DiffEqFlux.jl, group: DiffEqFlux}
-          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
+          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE1}
+          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE2}
           - {user: SciML, repo: ModelingToolkit.jl, group: All}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -49,14 +49,3 @@ run_qa(
     ),
     ei_broken = (:no_implicit_imports,),
 )
-
-@testset "NeuralPDE downstream groups" begin
-    workflow = read(
-        joinpath(@__DIR__, "..", "..", ".github", "workflows", "Downstream.yml"), String
-    )
-    groups = [
-        only(m.captures) for m in
-            eachmatch(r"\{user: SciML, repo: NeuralPDE\.jl, group: ([^}]+)\}", workflow)
-    ]
-    @test groups == ["NNPDE1", "NNPDE2"]
-end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -49,3 +49,14 @@ run_qa(
     ),
     ei_broken = (:no_implicit_imports,),
 )
+
+@testset "NeuralPDE downstream groups" begin
+    workflow = read(
+        joinpath(@__DIR__, "..", "..", ".github", "workflows", "Downstream.yml"), String
+    )
+    groups = [
+        only(m.captures) for m in
+            eachmatch(r"\{user: SciML, repo: NeuralPDE\.jl, group: ([^}]+)\}", workflow)
+    ]
+    @test groups == ["NNPDE1", "NNPDE2"]
+end


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Request

> https://github.com/SciML/NeuralPDE.jl/pull/1084 update Optimization.jl's downstream workflow instead

## Summary

- Replace Optimization.jl's obsolete NeuralPDE `NNPDE` downstream job with separate `NNPDE1` and `NNPDE2` jobs.
- Add a QA regression test that locks the NeuralPDE group names used by the downstream workflow.

## Root cause

NeuralPDE now declares folder-mode groups `NNPDE1` and `NNPDE2`. Optimization.jl still requested the removed aggregate `NNPDE` group, so SciMLTesting rejected the downstream job before running NeuralPDE tests. The caller should request the groups NeuralPDE currently exposes instead of adding a compatibility alias to NeuralPDE, as proposed in the now-closed SciML/NeuralPDE.jl#1084.

## Impact

Optimization's downstream CI now exercises both halves of NeuralPDE's NNPDE suite in independent jobs. NeuralPDE's own test runner and generated CI matrix remain unchanged.

## Local verification

- `GROUP=QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`
  - observed `QA | 18 pass, 1 broken, 19 total`
  - final output: `Testing Optimization tests passed`
  - the broken item is the pre-existing declared `no_implicit_imports` QA check
- Reproduced `SciML/.github/.github/workflows/downstream.yml@v1` locally against NeuralPDE master `bfcbae6ab850b6e785e33d7972cbba787eac97e9`, with `Pkg.develop(PackageSpec(path="."))` selecting this Optimization checkout:
  - `GROUP=NNPDE1 julia +1.12 --startup-file=no --project=downstream -e 'using Pkg; Pkg.develop(PackageSpec(path=".")); Pkg.update(); Pkg.test(; coverage=false)'`
    - all 8 selected files passed; final output: `Testing NeuralPDE tests passed`
  - `GROUP=NNPDE2 julia +1.12 --startup-file=no --project=downstream -e 'using Pkg; Pkg.develop(PackageSpec(path=".")); Pkg.update(); Pkg.test(; coverage=false)'`
    - all 6 selected files passed; final output: `Testing NeuralPDE tests passed`
- `julia +1.12 --startup-file=no --project=.runic-env -m Runic --check .`
- `actionlint .github/workflows/Downstream.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/Downstream.yml"); puts "YAML parsed successfully"'`
- `git diff --check`
