### PR TITLE
Avoid BLAS dot in Enzyme lagrangian helper

### DIFF
--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -77,7 +77,11 @@ end
 function lagrangian(x, _f::Function, cons::Function, p, λ, σ = one(eltype(x)))
     res = zeros(eltype(x), length(λ))
     cons(res, x, p)
-    return σ * _f(x, p) + dot(λ, res)
+    cons_term = zero(eltype(res))
+    for i in eachindex(λ, res)
+        cons_term += λ[i] * res[i]
+    end
+    return σ * _f(x, p) + cons_term
 end
 
 function lag_grad(mode, x, dx, lagrangian::Function, _f::Function, cons::Function, p, σ, λ)


### PR DESCRIPTION
## What

Avoid `LinearAlgebra.dot` in the Enzyme-only lagrangian helper used for constrained Hessian generation. The helper now accumulates the constraint contribution explicitly, which avoids the Julia 1.13-rc1/Enzyme `ijl_lazy_load_and_lookup` derivative failure while preserving the same scalar value.

**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

## Why

`lib/OptimizationBase / Julia pre / Tests - Core` is failing on current `master` before the QA source-path cleanup PR can get a clean run. The failing stack is in `OptimizationEnzymeExt.lagrangian` through `LinearAlgebra.dot`.

Observed master failure on `794eef029d3183bfdb20b122bf6b26b969a0875c`:

```text
EnzymeNoDerivativeError: No augmented forward pass found for ijl_lazy_load_and_lookup
  dot @ LinearAlgebra/src/blas.jl
  lagrangian @ lib/OptimizationBase/ext/OptimizationEnzymeExt.jl:80
```

## Validation

On a clean worktree at current master plus this commit:

```text
OPTIMIZATION_TEST_GROUP=Core timeout 3600 julia +1.13 --project=lib/OptimizationBase -e 'using Pkg; Pkg.test()'
```

passed:

```text
Test Summary: | Pass  Total     Time
Core          |  777    777  7m16.2s
Testing OptimizationBase tests passed
```

Also ran:

```text
julia +1.12 --project=. -e 'import Runic; exit(Runic.main(["--check", "lib/OptimizationBase/ext/OptimizationEnzymeExt.jl"]))'
git diff --check
```
