### PR TITLE
Target ModelingToolkit optimization downstream tests

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -15,7 +15,7 @@ jobs:
           - {user: SciML, repo: DiffEqFlux.jl, group: DiffEqFlux}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE1}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE2}
-          - {user: SciML, repo: ModelingToolkit.jl, group: All}
+          - {user: SciML, repo: ModelingToolkit.jl, group: Optimization}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       owner: "${{ matrix.package.user }}"


### PR DESCRIPTION
> Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

Run ModelingToolkit's dedicated `Optimization` test group from Optimization.jl's downstream workflow instead of ModelingToolkit's aggregate `All` group.

## Why

The aggregate group runs ModelingToolkit's entire curated suite in one Julia process, including unrelated ControlSystems downstream coverage. In the repeated failing runs, an earlier group loaded LinearSolve 3.87, the downstream environment then resolved LinearSolve 4.3, and `LinearSolveArnoldiMethodExt` failed because the already-loaded 3.87 module did not define `ArnoldiMethodJL`.

Optimization.jl only needs ModelingToolkit's declared `Optimization` integration group. Selecting that group gives it its own declared test environment and avoids using Optimization.jl's downstream job as a general ModelingToolkit test job.

This is a test-setup-only change. It does not add an Enzyme compatibility restriction or alter package compatibility.

## Evidence

- The same unrelated `UndefVarError: ArnoldiMethodJL not defined in LinearSolve` occurred on [master](https://github.com/SciML/Optimization.jl/actions/runs/29209839041) and in [PR #1265's ModelingToolkit job](https://github.com/SciML/Optimization.jl/actions/runs/29212425356/job/86702294613).
- Local workflow-shaped run with Julia 1.12 and `GROUP=Optimization`: 156 passed, 1 pre-existing broken, 157 total; `Testing ModelingToolkit tests passed` (32m10.3s, exit 0).
- Local standalone `GROUP=Downstream` control: 31/31 passed (28m17.9s, exit 0).
- `actionlint .github/workflows/Downstream.yml`
- YAML parser load check
- `git diff --check`
- Runic 1.7.0 `--check` over all 165 tracked Julia files

## Investigation notes

- A history predicate bisect in LinearSolve found 571d0a868c490e420f3c48f469b1589adb72d746 as the first commit adding the ArnoldiMethod extension. The extension itself works in an isolated consistent environment; the failure requires mixed loaded/resolved LinearSolve versions.
- SciML/ModelingToolkit.jl#4730 proposed pinning LinearSolve in the unrelated downstream environment and was closed unmerged. Targeting the existing caller-specific group is smaller and avoids that pin.
- Prior art: Optimization.jl#1259 corrected NeuralPDE downstream group selection at the caller.

## Process

I inspected both failing job logs, reproduced the standalone groups locally with the reusable-workflow command shape, traced ModelingToolkit's `run_tests` group/environment declarations, checked relevant PR history, isolated the first extension-triggering LinearSolve commit, and validated this one-line workflow change. The requested scope was a cleaner test-setup fix that assumes upstream Enzyme support will be corrected before Julia 1.13 is released.
