### PR TITLE
Recognize explicit second-order AutoSparse AD

### DIFF
--- a/lib/OptimizationBase/src/cache.jl
+++ b/lib/OptimizationBase/src/cache.jl
@@ -74,6 +74,7 @@ function OptimizationCache(
 
     if !(
             prob.f.adtype isa DifferentiationInterface.SecondOrder ||
+                prob.f.adtype isa AutoSparse{<:DifferentiationInterface.SecondOrder} ||
                 prob.f.adtype isa AutoZygote
         ) &&
             (

--- a/lib/OptimizationBase/test/core_tests.jl
+++ b/lib/OptimizationBase/test/core_tests.jl
@@ -5,5 +5,6 @@ using Test
     include("matrixvalued.jl")
     include("solver_missing_error_messages.jl")
     include("lag_h_sigma_zero_test.jl")
+    include("second_order_warning_test.jl")
     include("solve_internals_test.jl")
 end

--- a/lib/OptimizationBase/test/second_order_warning_test.jl
+++ b/lib/OptimizationBase/test/second_order_warning_test.jl
@@ -1,0 +1,23 @@
+using DifferentiationInterface: SecondOrder
+using ForwardDiff
+
+struct ExactHessianOptimizer end
+
+SciMLBase.requireshessian(::ExactHessianOptimizer) = true
+
+@testset "explicit sparse second-order AD" begin
+    objective(x, p) = sum(abs2, x)
+    sparse_second_order = AutoSparse(
+        SecondOrder(AutoForwardDiff(), AutoForwardDiff())
+    )
+    explicit_f = OptimizationFunction(objective, sparse_second_order)
+    explicit_prob = OptimizationProblem(explicit_f, [1.0, 1.0])
+
+    @test_nowarn OptimizationCache(explicit_prob, ExactHessianOptimizer())
+
+    implicit_f = OptimizationFunction(objective, AutoSparse(AutoForwardDiff()))
+    implicit_prob = OptimizationProblem(implicit_f, [1.0, 1.0])
+    @test_logs (:warn, r"missing_second_order_ad") match_mode = :any OptimizationCache(
+        implicit_prob, ExactHessianOptimizer()
+    )
+end


### PR DESCRIPTION
## Summary

- recognize `AutoSparse` AD types that explicitly wrap `DifferentiationInterface.SecondOrder`
- retain the `missing_second_order_ad` warning for implicit first-order `AutoSparse` inputs
- add focused regression coverage for both cases

## Context

Optimization's exact-Hessian cache warning only recognized a top-level `SecondOrder`. The documented sparse form is instead `AutoSparse(SecondOrder(inner, outer))`, so an explicitly configured sparse second-order backend was incorrectly warned as missing second-order AD.

This became visible in BoundaryValueDiffEq after OptimizationIpopt 1.3 switched to the generic `OptimizationCache`. A separate downstream follow-up supplies an explicit sparse `SecondOrder`; this PR only fixes OptimizationBase's classification.

Related prior art: #1061 called out this false warning while working around it downstream, and #1240 concerns another second-order warning edge case. I found no open duplicate PR.

## Investigation

1. Reproduced the warning on current master and confirmed the parent of OptimizationIpopt 1.3 remained silent because it did not use the generic cache path.
2. Verified that `AutoSparse(SecondOrder(AutoForwardDiff(), AutoForwardDiff()))` solves successfully.
3. Verified that moving `AutoSparse` outside the individual `SecondOrder` backends is the working sparse representation; the alternative top-level construction fails in DifferentiationInterface's pullback path.
4. Added a positive no-warning assertion for explicit sparse second-order AD and a negative assertion that implicit sparse AD still warns.

## Local verification

- `OPTIMIZATION_TEST_GROUP=Core`: 54 passed
- `OPTIMIZATION_TEST_GROUP=QA`: 16 passed, 1 pre-existing broken assertion; package test passed
- Runic check on all changed Julia files: passed
- Stacked BoundaryValueDiffEq integration reproduction: 4/4 assertions passed across bounded and unbounded MIRK/Ipopt problems (no warning and successful return code for each)

Please ignore this draft until it has been reviewed by @ChrisRackauckas.