### PR TITLE
Select the DiffEqFlux downstream test suite

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: SciML, repo: DiffEqFlux.jl, group: DiffEqFlux}
+          - {user: SciML, repo: DiffEqFlux.jl, group: All}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE1}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE2}
           - {user: SciML, repo: ModelingToolkit.jl, group: All}


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- replace the stale DiffEqFlux `GROUP=DiffEqFlux` selection with the target's curated `All` suite
- leave the other downstream matrix entries unchanged

DiffEqFlux declares `BasicNeuralDE`, `AdvancedNeuralDE`, `Newton`, and `Layers`, with `All` selecting those four groups. It does not declare a `DiffEqFlux` group, so the old job did not select a real target test group.

## Local verification

- `actionlint .github/workflows/Downstream.yml`
- `julia +1.12 --startup-file=no -m Runic --check .`
- `git diff --check`
- exact Julia 1.12 downstream replay with `GROUP=All`, coverage enabled, and Optimization resolved from `../repos/Optimization.jl`

The exact replay completed with `Testing DiffEqFlux tests passed`. Its final and longest testset reported:

```text
Test Summary:   | Pass  Total      Time
Stiff Nested AD |    3      3  73m01.4s
```

The full downstream replay took approximately 3h49m.