### PR TITLE
Use rendered public API docs QA

### DIFF
--- a/docs/src/API/solve.md
+++ b/docs/src/API/solve.md
@@ -1,6 +1,7 @@
 # Common Solver Options (Solve Keyword Arguments)
 
 ```@docs
+OptimizationBase
 OptimizationBase.solve(::SciMLBase.OptimizationProblem,::Any)
 OptimizationBase.OptimizationCache
 OptimizationBase.DEFAULT_CALLBACK

--- a/lib/OptimizationAuglag/test/qa/qa.jl
+++ b/lib/OptimizationAuglag/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationAuglag, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -22,6 +24,9 @@ run_qa(
         all_explicit_imports_are_public = (; ignore = (:OptimizationStats,)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationAuglag),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationBBO/test/qa/qa.jl
+++ b/lib/OptimizationBBO/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationBBO, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -16,6 +18,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (Symbol("@logmsg"), :LogLevel, :OptRunController, :OptimizationState, :OptimizationStats, :SingleObjectiveMethodNames, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :allowscallback, :deduce_retcode, :elapsed_time, :num_steps, :requiresbounds, :shutdown_optimizer!)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationBBO),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationBase/src/OptimizationBase.jl
+++ b/lib/OptimizationBase/src/OptimizationBase.jl
@@ -1,3 +1,9 @@
+"""
+    OptimizationBase
+
+Core types, defaults, and solver interface extensions shared by the
+Optimization.jl solver packages.
+"""
 module OptimizationBase
 
 using DocStringExtensions

--- a/lib/OptimizationBase/test/qa/qa.jl
+++ b/lib/OptimizationBase/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationBase, JET, SciMLBase
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -39,6 +41,9 @@ run_qa(
         all_explicit_imports_are_public = (; ignore = (:KeywordArgError, :MaxSense, :MinSense, :ObjSense, :OptimizationStats, :__init, :__solve, :_concrete_solve_adjoint, :_concrete_solve_forward, :allowscallback, :extract_alg, :get_concrete_p, :get_concrete_u0, :get_root_indp, :get_updated_symbolic_problem, :has_kwargs, :promote_u0, :requiresbounds, :requiresconshess, :requiresconsjac, :requiresconstraints, :requiresgradient, :requireshessian, :wrap_sol)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationBase),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationCMAEvolutionStrategy/test/qa/qa.jl
+++ b/lib/OptimizationCMAEvolutionStrategy/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationCMAEvolutionStrategy, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -16,6 +18,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:BasicLogger, :OptimizationState, :OptimizationStats, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :allowscallback, :requiresconshess, :requiresconsjac, :requiresgradient, :requireshessian)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationCMAEvolutionStrategy),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationEvolutionary/test/qa/qa.jl
+++ b/lib/OptimizationEvolutionary/test/qa/qa.jl
@@ -1,5 +1,8 @@
 using SciMLTesting, OptimizationEvolutionary, JET, SciMLBase
 using Test
+
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 using Evolutionary
 
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
@@ -36,6 +39,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:AbstractOptimizer, :OptimizationState, :OptimizationStats, :OptimizationTrace, :OptimizationTraceRecord, :Options, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :allowscallback, :converged, :minimizer, :minimum, :optimize, :requiresconshess, :requiresconsjac, :requiresgradient, :requireshessian, :trace!, :update!)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationEvolutionary),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationGCMAES/test/qa/qa.jl
+++ b/lib/OptimizationGCMAES/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationGCMAES, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -16,6 +18,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:OptimizationStats, :__init, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :allowscallback, :maximize, :minimize, :requiresbounds, :requiresconshess, :requiresconsjac, :requiresgradient, :requireshessian, :supports_sense)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationGCMAES),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationIpopt/test/qa/qa.jl
+++ b/lib/OptimizationIpopt/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationIpopt, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -16,6 +18,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (Symbol("@logmsg"), :ApplicationReturnStatus, :Diverging_Iterates, :Feasible_Point_Found, :GetIpoptCurrentIterate, :Infeasible_Problem_Detected, :LogLevel, :Maximum_CpuTime_Exceeded, :Maximum_Iterations_Exceeded, :Maximum_WallTime_Exceeded, :OptimizationState, :OptimizationStats, :Search_Direction_Becomes_Too_Small, :Solve_Succeeded, :Solved_To_Acceptable_Level, :User_Requested_Stop, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :allowscallback, :instantiate_function, :requiresconshess, :requiresconsjac, :requiresgradient, :requireshessian, :requireslagh, :supports_sense)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationIpopt),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationLBFGSB/test/qa/qa.jl
+++ b/lib/OptimizationLBFGSB/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationLBFGSB, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -17,6 +19,9 @@ run_qa(
         all_explicit_imports_are_public = (; ignore = (:OptimizationStats, :deduce_retcode)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationLBFGSB),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationMOI/test/qa/qa.jl
+++ b/lib/OptimizationMOI/test/qa/qa.jl
@@ -1,5 +1,8 @@
 using SciMLTesting, OptimizationMOI, JET, OptimizationBase, SciMLBase
 using Test
+
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 using MathOptInterface
 
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
@@ -45,6 +48,9 @@ run_qa(
         all_explicit_imports_are_public = (; ignore = (:varmap_to_vars,)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationMOI),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationMadNLP/test/qa/qa.jl
+++ b/lib/OptimizationMadNLP/test/qa/qa.jl
@@ -25,7 +25,10 @@ run_qa(
     api_docs_kwargs = (;
         rendered = true,
         docs_src = OPTIMIZATION_DOCS_SRC,
-        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationMadNLP),
+        rendered_ignore = (
+            optimization_dependency_rendered_ignore(OptimizationMadNLP)...,
+            :solve!,
+        ),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationMadNLP/test/qa/qa.jl
+++ b/lib/OptimizationMadNLP/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationMadNLP, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -21,6 +23,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (Symbol("@logmsg"), :AbstractBarrierUpdate, :AbstractMadNLPSolver, :AbstractUserCallback, :DIVERGING_ITERATES, :ExactHessian, :INFEASIBLE_PROBLEM_DETECTED, :INFO, :LogLevel, :LogLevels, :MAXIMUM_ITERATIONS_EXCEEDED, :MAXIMUM_WALLTIME_EXCEEDED, :NOT_ENOUGH_DEGREES_OF_FREEDOM, :OptimizationState, :OptimizationStats, :QuasiNewtonOptions, :RESTORATION_FAILED, :SEARCH_DIRECTION_BECOMES_TOO_SMALL, :SOLVED_TO_ACCEPTABLE_LEVEL, :SOLVE_SUCCEEDED, :Status, :USER_REQUESTED_STOP, :WARN, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :allowscallback, :allowsconsjvp, :allowsconsvjp, :requiresconshess, :requiresconsjac, :requiresgradient, :requireshessian, :requireslagh, :supports_sense)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationMadNLP),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationManopt/test/qa/qa.jl
+++ b/lib/OptimizationManopt/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationManopt, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -21,6 +23,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:AbstractManifold, :OptimizationState, :__solve, :allowscallback, :build_solution, :requiresgradient, :requireshessian, :supports_sense)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationManopt),
         ignore = (
             :AbstractManifoldGradientObjective,
             :Gradient,

--- a/lib/OptimizationMetaheuristics/test/qa/qa.jl
+++ b/lib/OptimizationMetaheuristics/test/qa/qa.jl
@@ -41,7 +41,10 @@ run_qa(
     api_docs_kwargs = (;
         rendered = true,
         docs_src = OPTIMIZATION_DOCS_SRC,
-        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationMetaheuristics),
+        rendered_ignore = (
+            optimization_dependency_rendered_ignore(OptimizationMetaheuristics)...,
+            :summary,
+        ),
         ignore = (
             :ArasMethod,
             :AutoModelingToolkit,

--- a/lib/OptimizationMetaheuristics/test/qa/qa.jl
+++ b/lib/OptimizationMetaheuristics/test/qa/qa.jl
@@ -1,5 +1,8 @@
 using SciMLTesting, OptimizationMetaheuristics, JET, SciMLBase
 using Test
+
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 using Metaheuristics
 
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
@@ -36,6 +39,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:AbstractAlgorithm, :OptimizationStats, :__init, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :allowscallback, :create_child, :get_best, :requiresbounds)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationMetaheuristics),
         ignore = (
             :ArasMethod,
             :AutoModelingToolkit,

--- a/lib/OptimizationMultistartOptimization/test/qa/qa.jl
+++ b/lib/OptimizationMultistartOptimization/test/qa/qa.jl
@@ -1,5 +1,8 @@
 using SciMLTesting, OptimizationMultistartOptimization, JET, SciMLBase
 using Test
+
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 using MultistartOptimization
 
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
@@ -35,6 +38,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:OptimizationStats, :__init, :__solve, :allowscallback, :requiresbounds)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationMultistartOptimization),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationNLPModels/test/qa/qa.jl
+++ b/lib/OptimizationNLPModels/test/qa/qa.jl
@@ -1,5 +1,8 @@
 using SciMLTesting, OptimizationNLPModels, JET, SciMLBase
 using Test
+
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 using NLPModels
 
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
@@ -29,6 +32,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:NoAD,)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationNLPModels),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationNLopt/test/qa/qa.jl
+++ b/lib/OptimizationNLopt/test/qa/qa.jl
@@ -1,5 +1,8 @@
 using SciMLTesting, OptimizationNLopt, JET, OptimizationBase, SciMLBase
 using Test
+
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 using NLopt
 
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
@@ -41,6 +44,9 @@ run_qa(
         all_explicit_imports_are_public = (; ignore = (:deduce_retcode,)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationNLopt),
         ignore = (
             :Algorithm,
             :AutoModelingToolkit,

--- a/lib/OptimizationNOMAD/test/qa/qa.jl
+++ b/lib/OptimizationNOMAD/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationNOMAD, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -21,6 +23,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:DefaultOptimizationCache, :OptimizationStats, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :allowscallback)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationNOMAD),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationODE/test/qa/qa.jl
+++ b/lib/OptimizationODE/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationODE, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -16,6 +18,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:OptimizationStats, :__init, :__solve, :allowscallback, :requiresbounds, :requiresconshess, :requiresconsjac, :requiresgradient, :requireshessian)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationODE),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationOptimJL/test/qa/qa.jl
+++ b/lib/OptimizationOptimJL/test/qa/qa.jl
@@ -1,5 +1,8 @@
 using SciMLTesting, OptimizationOptimJL, JET, OptimizationBase, SciMLBase
 using Test
+
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 using Optim
 
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
@@ -39,6 +42,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:AbstractConstrainedOptimizer, :AbstractOptimizer, :ConstrainedOptimizer, :KrylovTrustRegion, :NLSolversBase, :NoAD, :OptimizationState, :OptimizationStats, :Options, :ZerothOrderOptimizer, :__init, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :alloc_DF, :alloc_H, :allowscallback, :allowsfg, :converged, :iteration_limit_reached, :requiresbounds, :requiresconshess, :requiresconsjac, :requiresgradient, :requireshessian, :supports_sense, :value)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationOptimJL),
         ignore = (
             :AcceleratedGradientDescent,
             :AutoModelingToolkit,

--- a/lib/OptimizationOptimisers/test/qa/qa.jl
+++ b/lib/OptimizationOptimisers/test/qa/qa.jl
@@ -1,5 +1,8 @@
 using SciMLTesting, OptimizationOptimisers, JET, SciMLBase
 using Test
+
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 using Optimisers
 
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
@@ -32,6 +35,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:OptimizationState, :OptimizationStats, :__init, :__solve, :_check_and_convert_maxiters, :allowscallback, :allowsfg, :isa_dataiterator, :requiresgradient)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationOptimisers),
         ignore = (
             :ADADelta,
             :ADAGrad,

--- a/lib/OptimizationPRIMA/test/qa/qa.jl
+++ b/lib/OptimizationPRIMA/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationPRIMA, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -14,6 +16,11 @@ run_qa(
     ei_kwargs = (;
         all_qualified_accesses_via_owners = (; ignore = (:OptimizationStats,)),
         all_qualified_accesses_are_public = (; ignore = (:AnalysisResults, :DAMAGING_ROUNDING, :FTARGET_ACHIEVED, :INVALID_INPUT, :MAXFUN_REACHED, :MAXTR_REACHED, :NAN_INF_F, :NAN_INF_MODEL, :NAN_INF_X, :NO_SPACE_BETWEEN_BOUNDS, :NoAD, :OptimizationState, :OptimizationStats, :ReInitCache, :SMALL_TR_RADIUS, :Status, :ZERO_LINEAR_CONSTRAINT, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :_process_verbose_param, :allowscallback, :apply_sense, :instantiate_function, :requiresconshess, :requiresconsjac, :requiresconstraints, :supports_sense)),
+    ),
+    api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationPRIMA),
     ),
     ei_broken = (:no_implicit_imports,),
 )

--- a/lib/OptimizationPolyalgorithms/test/qa/qa.jl
+++ b/lib/OptimizationPolyalgorithms/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationPolyalgorithms, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -15,6 +17,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:__solve, :allowscallback, :requiresgradient)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationPolyalgorithms),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationPyCMA/test/qa/qa.jl
+++ b/lib/OptimizationPyCMA/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationPyCMA, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl. This env
 # can only be analyzed where CondaPkg can run; the broken checks are the
 # `@reexport`/`using` module-name relies plus qualified accesses to SciMLBase/
@@ -9,6 +11,9 @@ run_qa(
     OptimizationPyCMA;
     explicit_imports = true,
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationPyCMA),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationQuadDIRECT/test/qa/qa.jl
+++ b/lib/OptimizationQuadDIRECT/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationQuadDIRECT, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -16,6 +18,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:DefaultOptimizationCache, :OptimizationStats, :__solve, :_check_and_convert_maxiters, :allowscallback, :position, :requiresbounds)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationQuadDIRECT),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationSciPy/test/qa/qa.jl
+++ b/lib/OptimizationSciPy/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationSciPy, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl. This env
 # can only be analyzed where CondaPkg can run; the broken checks are the
 # `@reexport`/`using` module-name relies plus qualified accesses to SciMLBase/
@@ -9,6 +11,9 @@ run_qa(
     OptimizationSciPy;
     explicit_imports = true,
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationSciPy),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationSophia/test/qa/qa.jl
+++ b/lib/OptimizationSophia/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationSophia, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -15,6 +17,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:OptimizationState, :__init, :__solve, :_check_and_convert_maxiters, :allowscallback, :allowsfg, :isa_dataiterator, :requiresgradient, :requireshessian)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationSophia),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/OptimizationSpeedMapping/test/qa/qa.jl
+++ b/lib/OptimizationSpeedMapping/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, OptimizationSpeedMapping, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -16,6 +18,9 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:OptimizationStats, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :allowscallback, :requiresgradient)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(OptimizationSpeedMapping),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/lib/SimpleOptimization/test/qa/qa.jl
+++ b/lib/SimpleOptimization/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, SimpleOptimization, JET
 using Test
 
+include(normpath(joinpath(@__DIR__, "..", "..", "..", "..", "test", "qa", "rendered_docs.jl")))
+
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
 #  * no_implicit_imports broken: the module relies on `@reexport`/`using`
 #    module names (SciMLBase/OptimizationBase/Reexport/...) that cannot be made
@@ -20,6 +22,9 @@ run_qa(
         all_explicit_imports_are_public = (; ignore = (:_unwrap_val,)),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(SimpleOptimization),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,8 @@
 using SciMLTesting, Optimization, JET, SciMLBase
 using Test
 
+include("rendered_docs.jl")
+
 # no_implicit_imports: Optimization is a facade that `@reexport`s SciMLBase/ADTypes/
 # OptimizationBase and `using`s many helper modules; the implicit-import surface is
 # large and intentional. Tracked as known-broken (SciML/Optimization.jl).
@@ -37,6 +39,9 @@ run_qa(
         ),
     ),
     api_docs_kwargs = (;
+        rendered = true,
+        docs_src = OPTIMIZATION_DOCS_SRC,
+        rendered_ignore = optimization_dependency_rendered_ignore(Optimization),
         ignore = (
             :AutoModelingToolkit,
             :AutoSparseFastDifferentiation,

--- a/test/qa/rendered_docs.jl
+++ b/test/qa/rendered_docs.jl
@@ -1,0 +1,86 @@
+using SciMLTesting: public_api_names
+
+const OPTIMIZATION_DOCS_SRC = normpath(joinpath(@__DIR__, "..", "..", "docs", "src"))
+
+const OPTIMIZATION_OWNED_MODULES = Set(
+    (
+        :Optimization,
+        :OptimizationAuglag,
+        :OptimizationBBO,
+        :OptimizationBase,
+        :OptimizationCMAEvolutionStrategy,
+        :OptimizationEvolutionary,
+        :OptimizationGCMAES,
+        :OptimizationIpopt,
+        :OptimizationLBFGSB,
+        :OptimizationMOI,
+        :OptimizationMadNLP,
+        :OptimizationManopt,
+        :OptimizationMetaheuristics,
+        :OptimizationMultistartOptimization,
+        :OptimizationNLPModels,
+        :OptimizationNLopt,
+        :OptimizationNOMAD,
+        :OptimizationODE,
+        :OptimizationOptimJL,
+        :OptimizationOptimisers,
+        :OptimizationPRIMA,
+        :OptimizationPolyalgorithms,
+        :OptimizationPyCMA,
+        :OptimizationQuadDIRECT,
+        :OptimizationSciPy,
+        :OptimizationSophia,
+        :OptimizationSpeedMapping,
+        :SimpleOptimization,
+    )
+)
+
+function optimization_rendered_doc_names(docs_src::AbstractString)
+    rendered = Set{Symbol}()
+    isdir(docs_src) || return rendered
+    for (root, _, files) in walkdir(docs_src)
+        for file in files
+            endswith(file, ".md") || continue
+            in_docs = false
+            for raw in eachline(joinpath(root, file))
+                line = strip(raw)
+                if startswith(line, "```@docs")
+                    in_docs = true
+                    continue
+                elseif startswith(line, "```")
+                    in_docs = false
+                    continue
+                end
+                in_docs || continue
+                isempty(line) && continue
+                token = first(split(line))
+                token = first(split(token, '('))
+                dot = findlast(==('.'), token)
+                dot === nothing || (token = token[nextind(token, dot):end])
+                push!(rendered, Symbol(token))
+            end
+        end
+    end
+    return rendered
+end
+
+function optimization_dependency_rendered_ignore(pkg::Module)
+    rendered = optimization_rendered_doc_names(OPTIMIZATION_DOCS_SRC)
+    ignored = Symbol[]
+    for name in public_api_names(pkg)
+        name in rendered && continue
+        isdefined(pkg, name) || continue
+        owner = try
+            value = getproperty(pkg, name)
+            nameof(parentmodule(value))
+        catch
+            try
+                nameof(parentmodule(typeof(getproperty(pkg, name))))
+            catch
+                nameof(pkg)
+            end
+        end
+        owner in OPTIMIZATION_OWNED_MODULES || push!(ignored, name)
+    end
+    return Tuple(sort!(unique(ignored)))
+end


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Enable SciMLTesting rendered public API docs QA across Optimization.jl QA groups with `api_docs_kwargs = (; rendered = true, ...)`.
- Add a shared helper that computes `rendered_ignore` only for dependency-owned reexports not rendered in the Optimization docs.
- Render the package-owned `OptimizationBase` module and add its source module docstring.

## Validation
- `git diff --check` passed with no output.
- Runic via Julia 1.10 passed with no output over touched Julia files.
- Direct rendered docs QA for `Optimization`: `Public API documentation | 2 pass / 2 total`.
- Direct rendered docs QA for `OptimizationBase`: `Public API documentation | 2 pass / 2 total`.
- `GROUP=QA Pkg.test` on Julia 1.10: `QA | 17 pass, 1 broken, 18 total`; `Testing Optimization tests passed`.
- `GROUP=OptimizationBase_QA Pkg.test` on Julia 1.10: `QA | 17 pass, 1 broken, 18 total`; `Testing OptimizationBase tests passed`; `Testing Optimization tests passed`.
- `GROUP=OptimizationOptimJL_QA Pkg.test` on Julia 1.10: `Quality Assurance | 17 pass, 1 broken, 18 total`; `Testing OptimizationOptimJL tests passed`; `Testing Optimization tests passed`.
- `GROUP=OptimizationPRIMA_QA Pkg.test` on Julia 1.10: `Quality Assurance | 17 pass, 1 broken, 18 total`; `Testing OptimizationPRIMA tests passed`; `Testing Optimization tests passed`.
- `docs/make.jl` on Julia 1.10 passed after local docs env resolution; final output reached `HTMLWriter: rendering HTML pages` and skipped deployment outside CI. Linkcheck emitted existing redirect warnings.