### PR TITLE
Support non-Array AbstractVectors for AutoEnzyme hess and fgh!

### DIFF
--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -195,8 +195,13 @@ function OptimizationBase.instantiate_function(
             vdθ = Tuple((Array(r) for r in eachrow(I(length(θ)) * one(eltype(θ)))))
             vdbθ = Tuple(zeros(eltype(θ), length(θ)) for i in eachindex(θ))
             θ_arr = θ isa Array ? θ : Array(θ)
-            G_arr = G isa Array ? G : Array(G)
-            Enzyme.make_zero!(G_arr)
+            if G isa Array
+                G_arr = G
+                Enzyme.make_zero!(G)
+            else
+                G_arr = Array(G)
+                Enzyme.make_zero!(G_arr)
+            end
 
             Enzyme.autodiff(
                 fmode,
@@ -208,8 +213,8 @@ function OptimizationBase.instantiate_function(
                 Const(p)
             )
 
-            if G !== G_arr
-                G .= G_arr
+            if !(G isa Array)
+                copyto!(G, G_arr)
             end
 
             for i in eachindex(θ)

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -196,6 +196,7 @@ function OptimizationBase.instantiate_function(
             vdbθ = Tuple(zeros(eltype(θ), length(θ)) for i in eachindex(θ))
             θ_arr = θ isa Array ? θ : Array(θ)
             G_arr = G isa Array ? G : Array(G)
+            Enzyme.make_zero!(G_arr)
 
             Enzyme.autodiff(
                 fmode,

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -196,7 +196,9 @@ function OptimizationBase.instantiate_function(
             vdbθ = Tuple(zeros(eltype(θ), length(θ)) for i in eachindex(θ))
             θ_arr = θ isa Array ? θ : Array(θ)
             G_arr = G isa Array ? G : Array(G)
-            Enzyme.make_zero!(G_arr)
+            if !(G isa Array)
+                Enzyme.make_zero!(G_arr)
+            end
 
             Enzyme.autodiff(
                 fmode,

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -196,6 +196,7 @@ function OptimizationBase.instantiate_function(
             vdbθ = Tuple(zeros(eltype(θ), length(θ)) for i in eachindex(θ))
             θ_arr = θ isa Array ? θ : Array(θ)
             G_arr = G isa Array ? G : Array(G)
+            Enzyme.make_zero!(G_arr)
 
             Enzyme.autodiff(
                 fmode,
@@ -206,6 +207,10 @@ function OptimizationBase.instantiate_function(
                 Const(f.f),
                 Const(p)
             )
+
+            if G !== G_arr
+                G .= G_arr
+            end
 
             for i in eachindex(θ)
                 H[i, :] .= vdbθ[i]

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -167,12 +167,13 @@ function OptimizationBase.instantiate_function(
         function hess(res, θ, p = p)
             Enzyme.make_zero!(bθ)
             Enzyme.make_zero!.(vdbθ)
+            θ_arr = θ isa Array ? θ : Array(θ)
 
             Enzyme.autodiff(
                 fmode,
                 inner_grad,
                 Const(rmode),
-                Enzyme.BatchDuplicated(θ, vdθ),
+                Enzyme.BatchDuplicated(θ_arr, vdθ),
                 Enzyme.BatchDuplicatedNoNeed(bθ, vdbθ),
                 Const(f.f),
                 Const(p)
@@ -193,13 +194,15 @@ function OptimizationBase.instantiate_function(
         function fgh!(G, H, θ, p = p)
             vdθ = Tuple((Array(r) for r in eachrow(I(length(θ)) * one(eltype(θ)))))
             vdbθ = Tuple(zeros(eltype(θ), length(θ)) for i in eachindex(θ))
+            θ_arr = θ isa Array ? θ : Array(θ)
+            G_arr = G isa Array ? G : Array(G)
 
             Enzyme.autodiff(
                 fmode,
                 inner_grad,
                 Const(rmode),
-                Enzyme.BatchDuplicated(θ, vdθ),
-                Enzyme.BatchDuplicatedNoNeed(G, vdbθ),
+                Enzyme.BatchDuplicated(θ_arr, vdθ),
+                Enzyme.BatchDuplicatedNoNeed(G_arr, vdbθ),
                 Const(f.f),
                 Const(p)
             )

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -195,13 +195,7 @@ function OptimizationBase.instantiate_function(
             vdθ = Tuple((Array(r) for r in eachrow(I(length(θ)) * one(eltype(θ)))))
             vdbθ = Tuple(zeros(eltype(θ), length(θ)) for i in eachindex(θ))
             θ_arr = θ isa Array ? θ : Array(θ)
-            if G isa Array
-                G_arr = G
-                Enzyme.make_zero!(G)
-            else
-                G_arr = Array(G)
-                Enzyme.make_zero!(G_arr)
-            end
+            G_arr = G isa Array ? G : Array(G)
 
             Enzyme.autodiff(
                 fmode,

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -196,9 +196,7 @@ function OptimizationBase.instantiate_function(
             vdbθ = Tuple(zeros(eltype(θ), length(θ)) for i in eachindex(θ))
             θ_arr = θ isa Array ? θ : Array(θ)
             G_arr = G isa Array ? G : Array(G)
-            if !(G isa Array)
-                Enzyme.make_zero!(G_arr)
-            end
+            Enzyme.make_zero!(G_arr)
 
             Enzyme.autodiff(
                 fmode,

--- a/lib/OptimizationBase/test/AD/adtests.jl
+++ b/lib/OptimizationBase/test/AD/adtests.jl
@@ -114,6 +114,20 @@ optprob.cons_h(H3, x0)
     optprob.lag_h(H4, x0, σ, μ)
     @test H4 ≈ σ * H2 + μ[1] * H3[1] rtol = 1.0e-6
 
+    # Test non-Vector AbstractVector (e.g. SubArray) for AutoEnzyme hess and fgh!
+    x_view = @view zeros(4)[1:2]
+    optprob_view = OptimizationBase.instantiate_function(
+        OptimizationFunction(rosenbrock, OptimizationBase.AutoEnzyme()), x_view,
+        OptimizationBase.AutoEnzyme(), nothing, 0, h = true, fgh = true
+    )
+    H_view = Array{Float64}(undef, 2, 2)
+    G_view = Array{Float64}(undef, 2)
+    optprob_view.hess(H_view, x_view)
+    @test H1 == H_view
+    optprob_view.fgh(G_view, H_view, x_view)
+    @test G1 == G_view
+    @test H1 == H_view
+
     G2 = Array{Float64}(undef, 2)
     H2 = Array{Float64}(undef, 2, 2)
 


### PR DESCRIPTION
Found this while doing the second order scimlsensitivity testing

```
In OptimizationEnzymeExt.jl (

lines 157–165
), the Hessian (hess) and gradient-Hessian (fgh!) builders construct the shadow vectors using plain Array(r) and zeros(eltype(x), length(x)):

julia
# In OptimizationEnzymeExt.jl (CURRENT CODE)
vdθ  = Tuple((Array(r) for r in eachrow(I(length(x)) * one(eltype(x)))))  # NTuple{N, Vector}
bθ   = zeros(eltype(x), length(x))                                        # Vector
vdbθ = Tuple(zeros(eltype(x), length(x)) for i in eachindex(x))            # NTuple{N, Vector}
When x (or θ) is a custom container type like ComponentVector, θ has type ComponentVector{...}, but its shadows in vdθ, bθ, and vdbθ are plain Vectors.

Enzyme requires BatchDuplicated(primal, shadow) to have the exact same type for both primal and shadow elements (T and NTuple{N, T}). Passing Vector shadows for a ComponentVector primal causes Enzyme.BatchDuplicated to fail with a MethodError.
```