### PR TITLE
Stabilize OptimizationBBO multi-objective tests

### DIFF
--- a/lib/OptimizationBBO/test/core_tests.jl
+++ b/lib/OptimizationBBO/test/core_tests.jl
@@ -119,6 +119,7 @@ using Random
 
             mof_1 = MultiObjectiveOptimizationFunction(multi_obj_func_1)
             prob_1 = OptimizationBase.OptimizationProblem(mof_1, u0; lb = lb, ub = ub)
+            Random.seed!(1234)
             sol_1 = solve(
                 prob_1, opt, NumDimensions = 2,
                 FitnessScheme = ParetoFitnessScheme{2}(is_minimizing = true)
@@ -150,6 +151,7 @@ using Random
 
             mof_1 = MultiObjectiveOptimizationFunction(multi_obj_func_1)
             prob_1 = OptimizationBase.OptimizationProblem(mof_1, u0; lb = lb, ub = ub)
+            Random.seed!(1234)
             sol_1 = solve(
                 prob_1, opt, NumDimensions = 2,
                 FitnessScheme = ParetoFitnessScheme{2}(is_minimizing = true),
@@ -178,6 +180,7 @@ using Random
 
             mof_2 = MultiObjectiveOptimizationFunction(multi_obj_func_2)
             prob_2 = OptimizationBase.OptimizationProblem(mof_2, u0; lb = lb, ub = ub)
+            Random.seed!(1234)
             sol_2 = solve(
                 prob_2, opt, NumDimensions = 2,
                 FitnessScheme = ParetoFitnessScheme{2}(is_minimizing = true)
@@ -200,6 +203,7 @@ using Random
 
             mof_3 = MultiObjectiveOptimizationFunction(multi_obj_func_3)
             prob_3 = OptimizationBase.OptimizationProblem(mof_3, u0; lb = lb, ub = ub)
+            Random.seed!(1234)
             sol_3 = solve(
                 prob_3, opt, NumDimensions = 2,
                 FitnessScheme = ParetoFitnessScheme{2}(is_minimizing = true)


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Seed Julia's RNG immediately before each OptimizationBBO multi-objective solve.
- Keep the existing expected objective values and tolerances unchanged.
- Make the random initial population independent of an earlier time-limited solve and machine load.

## Investigation

The current downgrade workflow reached the OptimizationBBO tests and exposed a pre-existing stochastic failure. The trigger commit changed only the root `Optim` compat; its diff contains no OptimizationBBO, OptimizationBase, or downgrade-workflow changes.

History analysis identifies `a8299ec5b` (2024-08-18) as the commit that added the exact multi-objective assertions after the pre-existing `maxtime = 5` solve. That timed solve advances global RNG state by a load-dependent amount. BlackBoxOptim constructs its randomized initial population before applying its run-time seed, so the later asserted objectives varied across clean processes and CI machines. A 100-seed reproduction produced an assertion failure at seed 668073.

The fix seeds immediately before each solve, covering population construction as well as the subsequent optimizer run. It does not change production behavior, test tolerances, expected values, or test counts.

## Local verification

- Recreated the exact downgrade graph with Julia 1.10.11: BlackBoxOptim 0.6.3, OptimizationBase 5.2.1, SciMLBase 2.122.1.
- Ran the CI-equivalent OptimizationBBO Core command twice independently: `25 passed / 25 total` both times, with byte-identical Rosenbrock/Ackley objectives.
- Ran the same Core tests with the failed job's SciMLTesting 2.2.0 harness: `25 passed / 25 total`.
- Ran the current graph on Julia 1.12.6 with BlackBoxOptim 0.6.9 and SciMLBase 3.36.0: `25 passed / 25 total`.
- Ran repository-wide Runic: exit 0.
- Ran `git diff --check`: clean.

## Process notes

1. Reproduced the exact clean-master command rather than attributing the failure to the compat-only trigger commit.
2. Sampled independent seeds to establish stochasticity without weakening the assertion.
3. Traced the RNG ordering in BlackBoxOptim and the test's history.
4. Applied the smallest deterministic test setup and reran exact, pinned-harness, current, and formatting checks.