### PR TITLE
Bump OptimizationOptimisers to v0.3.20 for release

### DIFF
--- a/lib/OptimizationOptimisers/Project.toml
+++ b/lib/OptimizationOptimisers/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationOptimisers"
 uuid = "42dfb2eb-d2b4-4451-abcd-913932933ac1"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.19"
+version = "0.3.20"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"


### PR DESCRIPTION
Releases the unreleased fix on master: avoid discarded objective evaluations in OptimizationOptimisers (#1268).

Detected by comparing the `git-tree-sha1` of the latest live registered version in General against the `src` subtree on the default branch. Only the `version` field in `Project.toml` is changed. No local test run — CI on this PR is the check. Please ignore until reviewed by @ChrisRackauckas.