### PR TITLE
Bump OptimizationOptimisers to v0.3.20

### DIFF
--- a/lib/OptimizationOptimisers/Project.toml
+++ b/lib/OptimizationOptimisers/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationOptimisers"
 uuid = "42dfb2eb-d2b4-4451-abcd-913932933ac1"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.19"
+version = "0.3.20"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"


### PR DESCRIPTION
Bumps `OptimizationOptimisers` **v0.3.19 → v0.3.20** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Avoid discarded objective evaluations in OptimizationOptimisers (#1268) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)