### PR TITLE
[AI] OptimizationBase: use a supplied `f.grad` when synthesizing `fg!`

### DIFF
--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.2.2"
+version = "5.2.3"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -134,7 +134,11 @@ function OptimizationBase.instantiate_function(
         grad = nothing
     end
 
-    if fg == true && f.fg === nothing
+    if fg == true && f.fg === nothing && f.grad !== nothing
+        # A user-supplied gradient is authoritative; building an AD `fg!` off `f.f` would
+        # silently discard it for every value+gradient evaluation.
+        fg! = (res, θ, p = p) -> (f.grad(res, θ, p); f.f(θ, p))
+    elseif fg == true && f.fg === nothing
         function fg!(res, θ, p = p)
             Enzyme.make_zero!(res)
             y = Enzyme.autodiff(
@@ -526,7 +530,10 @@ function OptimizationBase.instantiate_function(
         grad = nothing
     end
 
-    if fg == true && f.fg === nothing
+    if fg == true && f.fg === nothing && f.grad !== nothing
+        # A user-supplied gradient is authoritative; see the in-place path above.
+        fg! = (θ, p = p) -> (f.f(θ, p), f.grad(θ, p))
+    elseif fg == true && f.fg === nothing
         res_fg = zeros(eltype(x), size(x))
         function fg!(θ, p = p)
             Enzyme.make_zero!(res_fg)

--- a/lib/OptimizationBase/ext/OptimizationZygoteExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationZygoteExt.jl
@@ -49,11 +49,13 @@ function OptimizationBase.instantiate_function(
         grad = nothing
     end
 
-    if fg == true && f.fg === nothing
-        # Prepare a gradient prep for fg unless we already have one from the
-        # `g == true && f.grad === nothing` branch above. When the user supplied
-        # `f.grad`, line 37 didn't run, so `prep_grad` was never assigned.
-        if !(g == true && f.grad === nothing)
+    if fg == true && f.fg === nothing && f.grad !== nothing
+        # A user-supplied gradient is authoritative; building an AD `fg!` off `f.f` would
+        # silently discard it for every value+gradient evaluation.
+        fg! = (res, θ, p = p) -> (f.grad(res, θ, p); f.f(θ, p))
+    elseif fg == true && f.fg === nothing
+        # `f.grad === nothing` here, so `g == true` means the branch above already built the prep.
+        if g == false
             prep_grad = prepare_gradient(f.f, adtype, x, Constant(p), strict = Val(false))
         end
         function fg!(res, θ)
@@ -406,7 +408,10 @@ function OptimizationBase.instantiate_function(
         grad = nothing
     end
 
-    if fg == true && f.fg === nothing
+    if fg == true && f.fg === nothing && f.grad !== nothing
+        # A user-supplied gradient is authoritative; see the dense path above.
+        fg! = (res, θ, p = p) -> (f.grad(res, θ, p); f.f(θ, p))
+    elseif fg == true && f.fg === nothing
         if g == false
             extras_grad = prepare_gradient(
                 f.f, adtype.dense_ad, x, Constant(p), strict = Val(false)

--- a/lib/OptimizationBase/src/OptimizationDIExt.jl
+++ b/lib/OptimizationBase/src/OptimizationDIExt.jl
@@ -98,14 +98,18 @@ function instantiate_function(
         nothing
     end
 
-    # Create fg! closures - need separate prep if g was false
-    fg! = if fg == true && f.fg === nothing
-        _prep_grad_fg = if g == false
-            prepare_gradient(f.f, adtype, x, Constant(p))
-        else
-            # Reuse the prep from gradient if available
-            prepare_gradient(f.f, adtype, x, Constant(p))
+    # A user-supplied `f.grad` is authoritative: building an AD `fg!` off `f.f` would silently
+    # discard it (and any tuned preparation behind it) for every value+gradient evaluation.
+    fg! = if fg == true && f.fg === nothing && f.grad !== nothing
+        let f = f, p = p
+            function (res, θ, p = p)
+                f.grad(res, θ, p)
+                return f.f(θ, p)
+            end
         end
+    elseif fg == true && f.fg === nothing
+        # Reuse the gradient prep when `grad` built one; they are the same DI operator.
+        _prep_grad_fg = g == true ? _prep_grad : prepare_gradient(f.f, adtype, x, Constant(p))
         if p !== SciMLBase.NullParameters() && p !== nothing
             let _prep_grad_fg = _prep_grad_fg, f = f, adtype = adtype
                 function (res, θ, p = p)
@@ -520,7 +524,11 @@ function instantiate_function(
     end
 
     # Create fg! closures
-    fg! = if fg == true && f.fg === nothing
+    fg! = if fg == true && f.fg === nothing && f.grad !== nothing
+        let f = f, p = p
+            (θ, p = p) -> (f.f(θ, p), f.grad(θ, p))
+        end
+    elseif fg == true && f.fg === nothing
         _prep_grad_fg = prepare_gradient(f.f, adtype, x, Constant(p))
         if p !== SciMLBase.NullParameters() && p !== nothing
             let _prep_grad_fg = _prep_grad_fg, f = f, adtype = adtype

--- a/lib/OptimizationBase/test/AD/adtests.jl
+++ b/lib/OptimizationBase/test/AD/adtests.jl
@@ -1379,3 +1379,47 @@ using MLUtils
     end
     @test G0 ≈ sum(stochgrads) rtol = 1.0e-1
 end
+
+@testset "user-supplied grad is used by the generated fg!" begin
+    # A supplied `f.grad` must drive `fg!` rather than being replaced by a fresh AD
+    # preparation: rebuilding it silently discards whatever tuning the caller did
+    # (SciML/Optimization.jl#1282).
+    ncalls = Ref(0)
+    rosen(x, p = nothing) = (1 - x[1])^2 + 100 * (x[2] - x[1]^2)^2
+    function rosen_grad!(res, x, p = nothing)
+        ncalls[] += 1
+        res[1] = -2 * (1 - x[1]) - 400 * x[1] * (x[2] - x[1]^2)
+        res[2] = 200 * (x[2] - x[1]^2)
+        return res
+    end
+
+    Gref = zeros(2)
+    rosen_grad!(Gref, [0.5, 0.7])
+
+    adtypes = (
+        AutoForwardDiff(), AutoReverseDiff(), AutoZygote(), AutoEnzyme(),
+        AutoSparse(AutoZygote()),
+    )
+    for adtype in adtypes, g in (false, true)
+        optf = OptimizationBase.instantiate_function(
+            OptimizationFunction(rosen, adtype; grad = rosen_grad!),
+            zeros(2), adtype, nothing; g = g, fg = true
+        )
+        optf.fg === nothing && continue
+        ncalls[] = 0
+        G = zeros(2)
+        y = optf.fg(G, [0.5, 0.7])
+        @test ncalls[] == 1
+        @test y ≈ rosen([0.5, 0.7])
+        @test G ≈ Gref
+
+        # Without a user gradient the AD path still has to build its own preparation,
+        # including when `fg` is requested but `g` is not.
+        optf_ad = OptimizationBase.instantiate_function(
+            OptimizationFunction(rosen, adtype), zeros(2), adtype, nothing; g = g, fg = true
+        )
+        Gad = zeros(2)
+        @test optf_ad.fg(Gad, [0.5, 0.7]) ≈ rosen([0.5, 0.7])
+        @test Gad ≈ Gref
+    end
+end


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

Fixes https://github.com/SciML/Optimization.jl/issues/1282.

## Root cause

Every AD extension gates `fg!` construction on `fg == true && f.fg === nothing` — **it never checks `f.grad`**. So when a caller supplies a gradient but not an `fg`, OptimizationBase builds a *brand-new* AD preparation over `f.f` and the supplied gradient is never called.

That was harmless while `allowsfg` was off for Optim. https://github.com/SciML/Optimization.jl/pull/1200 flipped it on, so every first-order line search started taking the rebuilt path.

Pathfinder.jl hits this squarely: it supplies `grad` wrapping `LogDensityProblems.logdensity_and_gradient` ([`Pathfinder/src/optimize.jl:26-28`](https://github.com/mlcolab/Pathfinder.jl/blob/main/src/optimize.jl)), i.e. Turing's own prepared AD path. Verified with a counter inside a user-supplied gradient over 100 LBFGS iterations:

```
allowsfg=true : user grad calls = 0,   raw primal calls = 0
allowsfg=false: user grad calls = 151, raw primal calls = 151
```

The replacement is far slower because Pathfinder's objective closure captures the whole `LogDensityProblem` (model + data + VarInfo), so Mooncake's tangent is that entire object graph and has to be zeroed before every reverse pass.

## Measurements

66-parameter hierarchical Turing model, 2400 observations, Mooncake, `Optim.LBFGS()`, Julia 1.11:

| | ms/call |
|---|---|
| Turing `logdensity_and_gradient` (what Pathfinder supplied) | 0.372 |
| OptimizationBase-rebuilt DI `value_and_gradient!` | 10.269 |

Flat profile of the rebuilt path: **2948 of 3085 samples (96%)** in `Mooncake.set_to_zero!!` / `set_to_zero_internal!!` / `_already_tracked!`. Only ~4% is actual derivative work.

End to end:

| | `allowsfg=false` (pre-#1200) | `allowsfg=true` (master) | this PR |
|---|---|---|---|
| `pathfinder` 1st | 23.6 s | 49.4 s | 24.0 s |
| `pathfinder` 2nd | **0.55 s** | **15.3 s** | **0.53 s** |
| `multipathfinder(8)` | 18.1 s | 139.2 s | 19.8 s |

The first-run component is the extra `prepare_gradient` — 70 s cold, 12.4 s warm — paid once per `solve`, i.e. once per Pathfinder path.

## Change

Prefer a supplied `f.grad` when synthesizing `fg!`, in `OptimizationDIExt.jl` (in-place and out-of-place), `OptimizationZygoteExt.jl` (dense and sparse), and `OptimizationEnzymeExt.jl` (both):

```julia
fg! = if fg == true && f.fg === nothing && f.grad !== nothing
    (res, θ, p = p) -> (f.grad(res, θ, p); f.f(θ, p))
elseif fg == true && f.fg === nothing
    ... existing AD path ...
```

Also drops the duplicated `prepare_gradient` in the DI extension, whose two branches were identical despite the comment claiming one reused the gradient preparation.

This is not Optim-specific: `OptimizationOptimisers`, `OptimizationSophia`, and `OptimizationAuglag` also set `allowsfg = true` and have been discarding user gradients the same way. They are covered too.

`OptimizationBase` 5.2.2 → 5.2.3.

## Test plan

New testset in `lib/OptimizationBase/test/AD/adtests.jl` covering ForwardDiff / ReverseDiff / Zygote / Enzyme / `AutoSparse(AutoZygote())` × `g ∈ (false, true)`, asserting the supplied gradient is called exactly once and that the AD path still builds its own preparation when no gradient is supplied.

Run locally on Julia 1.11:

- [x] `OPTIMIZATION_TEST_GROUP=AD Pkg.test()` for OptimizationBase — 775 pass, 0 fail
- [x] `Pkg.test()` for OptimizationOptimJL — 6969 pass, 0 fail
- [x] Runic clean
- [ ] CI green

A follow-up PR will fix two unrelated pre-existing bugs in `OptimizationEnzymeExt.jl`'s out-of-place `instantiate_function` noticed while working here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Uj4Pu1LKHYqLSTLfPYDPo
