### PR TITLE
[AI] OptimizationBase: fix Enzyme out-of-place grad/fg wiring

### DIFF
--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.2.3"
+version = "5.2.4"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -524,7 +524,7 @@ function OptimizationBase.instantiate_function(
             )
             return res
         end
-    elseif fg == true
+    elseif g == true
         grad = (θ, p = p) -> f.grad(θ, p)
     else
         grad = nothing
@@ -545,7 +545,7 @@ function OptimizationBase.instantiate_function(
                 Enzyme.Duplicated(θ, res_fg),
                 Const(p)
             )[2]
-            return y, res
+            return y, res_fg
         end
     elseif fg == true
         fg! = (θ, p = p) -> f.fg(θ, p)

--- a/lib/OptimizationBase/test/AD/adtests.jl
+++ b/lib/OptimizationBase/test/AD/adtests.jl
@@ -1423,3 +1423,32 @@ end
         @test Gad ≈ Gref
     end
 end
+
+@testset "Enzyme out-of-place grad/fg wiring" begin
+    rosen(x, p = nothing) = (1 - x[1])^2 + 100 * (x[2] - x[1]^2)^2
+    rosen_grad(x, p = nothing) = [
+        -2 * (1 - x[1]) - 400 * x[1] * (x[2] - x[1]^2),
+        200 * (x[2] - x[1]^2),
+    ]
+    ad = AutoEnzyme()
+    z = [0.5, 0.7]
+    gref = rosen_grad(z)
+
+    # `g` alone must honour a supplied gradient; it used to be gated on `fg`.
+    optf = OptimizationBase.instantiate_function(
+        OptimizationFunction{false}(rosen, ad; grad = rosen_grad),
+        zeros(2), ad, nothing; g = true, fg = false
+    )
+    @test optf.grad !== nothing
+    @test optf.grad(z) ≈ gref
+
+    # The AD `fg!` must return the buffer it differentiated into, with or without `g`.
+    for g in (false, true)
+        optf = OptimizationBase.instantiate_function(
+            OptimizationFunction{false}(rosen, ad), zeros(2), ad, nothing; g = g, fg = true
+        )
+        y, G = optf.fg(z)
+        @test y ≈ rosen(z)
+        @test G ≈ gref
+    end
+end


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

Rebased onto `master` now that https://github.com/SciML/Optimization.jl/pull/1283 has merged (as e254f946). This PR is now standalone: one commit, 2 source lines plus a testset.

Two pre-existing bugs in the `OptimizationFunction{false}` method of `OptimizationEnzymeExt.instantiate_function`, noticed while working on https://github.com/SciML/Optimization.jl/issues/1282. Neither is related to that regression.

### 1. Gradient fallback gated on the wrong flag

```julia
if g == true && f.grad === nothing
    ...
elseif fg == true          # <-- should be `g == true`
    grad = (θ, p = p) -> f.grad(θ, p)
```

`g = true, fg = false` with a supplied `f.grad` falls through to `grad = nothing`. Every other extension — and the in-place Enzyme method 400 lines up — gates on `g`.

### 2. `fg!` returns the wrong buffer

```julia
res_fg = zeros(eltype(x), size(x))
function fg!(θ, p = p)
    ...
    Enzyme.Duplicated(θ, res_fg),
    ...
    return y, res          # <-- should be `res_fg`
```

`res` belongs to the `grad` branch. With `g = false` it is never assigned and `fg!` throws; with `g = true` it silently returns the untouched gradient buffer.

## Observed, before vs after

Driver: `OptimizationFunction{false}(rosen, AutoEnzyme(); grad = rosen_grad)`, evaluated at `[0.5, 0.7]` where the true gradient is `[-91.0, 90.0]`.

| case | before | after |
|---|---|---|
| `g=true, fg=false`, user grad | `optf.grad === nothing` | `optf.grad(z) ≈ [-91.0, 90.0]` |
| `g=false, fg=true` | `UndefVarError: res not defined` | `y ≈ 20.5`, `G ≈ [-91.0, 90.0]` |
| `g=true, fg=true` | `G = [0.0, 0.0]` (silently wrong) | `G ≈ [-91.0, 90.0]` |

The third row is the dangerous one — a zero gradient with no error.

Note these paths need both `ChainRulesCore` and `Enzyme` loaded to be reached, since the extension trigger is `OptimizationEnzymeExt = ["ChainRulesCore", "Enzyme"]`; with only `Enzyme` loaded, `AutoEnzyme` falls through to the generic DI extension, which is presumably why this went unnoticed.

`OptimizationBase` 5.2.3 → 5.2.4.

## Test plan

New `"Enzyme out-of-place grad/fg wiring"` testset in `lib/OptimizationBase/test/AD/adtests.jl` covering all three cases above. All three fail on the parent branch.

Run locally on Julia 1.11:

- [x] `OPTIMIZATION_TEST_GROUP=AD Pkg.test()` for OptimizationBase — 781 pass, 0 fail (re-run after the rebase, against the new `master` base)
- [x] Confirmed the new testset fails without the two source-line changes
- [x] Runic clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Uj4Pu1LKHYqLSTLfPYDPo
