### PR TITLE
Skip missing_second_order_ad when analytical second-order derivatives are supplied

### DIFF
--- a/lib/OptimizationBase/src/cache.jl
+++ b/lib/OptimizationBase/src/cache.jl
@@ -72,23 +72,21 @@ function OptimizationCache(
         processed_verbose = _process_verbose_param(verbose)
     end
 
+    needs_hess = SciMLBase.requireshessian(opt) &&
+        prob.f.hess === nothing && prob.f.fgh === nothing && prob.f.hv === nothing
+    needs_cons_hess = SciMLBase.requiresconshess(opt) && prob.f.cons_h === nothing
+    needs_lag_hess = SciMLBase.requireslagh(opt) && prob.f.lag_h === nothing
+    needs_second_order = needs_hess || needs_cons_hess || needs_lag_hess
+
     if !(
             prob.f.adtype isa DifferentiationInterface.SecondOrder ||
                 prob.f.adtype isa AutoZygote
-        ) &&
-            (
-            SciMLBase.requireshessian(opt) || SciMLBase.requiresconshess(opt) ||
-                SciMLBase.requireslagh(opt)
-        )
+        ) && needs_second_order
         @SciMLMessage(
             lazy"The selected optimization algorithm requires second order derivatives, but `SecondOrder` ADtype was not provided. So a `SecondOrder` with $(prob.f.adtype) for both inner and outer will be created, this can be suboptimal and not work in some cases so an explicit `SecondOrder` ADtype is recommended.",
             processed_verbose, :missing_second_order_ad
         )
-    elseif prob.f.adtype isa AutoZygote &&
-            (
-            SciMLBase.requiresconshess(opt) || SciMLBase.requireslagh(opt) ||
-                SciMLBase.requireshessian(opt)
-        )
+    elseif prob.f.adtype isa AutoZygote && needs_second_order
         @SciMLMessage(
             lazy"The selected optimization algorithm requires second order derivatives, but `AutoZygote` ADtype was provided. So a `SecondOrder` with `AutoZygote` for inner and `AutoForwardDiff` for outer will be created, for choosing another pair an explicit `SecondOrder` ADtype is recommended.",
             processed_verbose, :incompatible_ad_backend

--- a/lib/OptimizationBase/test/core_tests.jl
+++ b/lib/OptimizationBase/test/core_tests.jl
@@ -5,5 +5,6 @@ using Test
     include("matrixvalued.jl")
     include("solver_missing_error_messages.jl")
     include("lag_h_sigma_zero_test.jl")
+    include("second_order_warning_test.jl")
     include("solve_internals_test.jl")
 end

--- a/lib/OptimizationBase/test/second_order_warning_test.jl
+++ b/lib/OptimizationBase/test/second_order_warning_test.jl
@@ -1,0 +1,35 @@
+using OptimizationBase
+using SciMLBase: NoAD, requireshessian
+using Test
+
+struct ExactHessianOptimizer end
+requireshessian(::ExactHessianOptimizer) = true
+
+@testset "missing_second_order_ad with analytical Hessian" begin
+    objective(x, p) = (1 - x[1])^2 + 100 * (x[2] - x[1]^2)^2
+    function objective_grad!(G, x, p)
+        G[1] = -2 * (1 - x[1]) - 400 * x[1] * (x[2] - x[1]^2)
+        G[2] = 200 * (x[2] - x[1]^2)
+        return nothing
+    end
+    function objective_hess!(H, x, p)
+        H[1, 1] = 2 - 400 * (x[2] - 3 * x[1]^2)
+        H[1, 2] = -400 * x[1]
+        H[2, 1] = -400 * x[1]
+        H[2, 2] = 200
+        return nothing
+    end
+
+    f_analytical = OptimizationFunction(
+        objective, NoAD();
+        grad = objective_grad!, hess = objective_hess!
+    )
+    prob_analytical = OptimizationProblem(f_analytical, zeros(2))
+    @test_nowarn OptimizationCache(prob_analytical, ExactHessianOptimizer())
+
+    f_missing = OptimizationFunction(objective, NoAD())
+    prob_missing = OptimizationProblem(f_missing, zeros(2))
+    @test_logs (:warn, r"missing_second_order_ad") match_mode = :any OptimizationCache(
+        prob_missing, ExactHessianOptimizer()
+    )
+end


### PR DESCRIPTION
﻿## Summary
- `OptimizationCache` emitted `missing_second_order_ad` whenever a Hessian-requiring optimizer was used without a `SecondOrder` AD type, even if `OptimizationFunction` already supplied analytical `hess` / `fgh` / `hv` (or `cons_h` / `lag_h`).
- That contradicts `instantiate_function` / DI paths, which use user second-order callbacks when present, and `generate_adtype(NoAD)`, which does not build a `SecondOrder` fallback.
- Gate the warning (and the AutoZygote sibling) on those callbacks actually being missing.

Fixes #1240

## Test plan
- [x] Added `second_order_warning_test.jl`: analytical `hess` + `NoAD` → no warn; missing hess → warn
- [ ] CI `OptimizationBase` tests
