### PR TITLE
Sync package versions with the General registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Optimization"
 uuid = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
-version = "5.6.5"
+version = "5.6.6"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/OptimizationAuglag/Project.toml
+++ b/lib/OptimizationAuglag/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationAuglag"
 uuid = "2ea93f80-9333-43a1-a68d-1f53b957a421"
 authors = ["paramthakkar123 <paramthakkar864@gmail.com>", "Sebastian Micluța-Câmpeanu <sebastian.mc95@proton.me>"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/OptimizationBBO/Project.toml
+++ b/lib/OptimizationBBO/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationBBO"
 uuid = "3e6eede4-6085-4f62-9a71-46d9bc1eb92b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.4.9"
+version = "0.4.10"
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"

--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.2.3"
+version = "5.2.4"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]

--- a/lib/OptimizationCMAEvolutionStrategy/Project.toml
+++ b/lib/OptimizationCMAEvolutionStrategy/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationCMAEvolutionStrategy"
 uuid = "bd407f91-200f-4536-9381-e4ba712f53f8"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.10"
+version = "0.3.11"
 [deps]
 CMAEvolutionStrategy = "8d3b24bd-414e-49e0-94fb-163cc3a3e411"
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"

--- a/lib/OptimizationEvolutionary/Project.toml
+++ b/lib/OptimizationEvolutionary/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationEvolutionary"
 uuid = "cb963754-43f6-435e-8d4b-99009ff27753"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.4.11"
+version = "0.4.12"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 Evolutionary = "86b6b26d-c046-49b6-aa0b-5f0f74682bd6"

--- a/lib/OptimizationGCMAES/Project.toml
+++ b/lib/OptimizationGCMAES/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationGCMAES"
 uuid = "6f0a0517-dbc2-4a7a-8a20-99ae7f27e911"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.10"
+version = "0.3.11"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"

--- a/lib/OptimizationLBFGSB/Project.toml
+++ b/lib/OptimizationLBFGSB/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationLBFGSB"
 uuid = "22f7324a-a79d-40f2-bebe-3af60c77bd15"
 authors = ["paramthakkar123 <paramthakkar864@gmail.com>"]
-version = "1.4.3"
+version = "1.4.4"
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LBFGSB = "5be7bae1-8223-5378-bac3-9e7378a2f6e6"

--- a/lib/OptimizationMOI/Project.toml
+++ b/lib/OptimizationMOI/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationMOI"
 uuid = "fd9f6733-72f4-499f-8506-86b2bdd0dea1"
-version = "1.3.3"
+version = "1.3.4"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]

--- a/lib/OptimizationMadNLP/Project.toml
+++ b/lib/OptimizationMadNLP/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationMadNLP"
 uuid = "5d9c809f-c847-4062-9fba-1793bbfef577"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Sebastian Micluța-Câmpeanu <sebastian.mc95@proton.me> and contributors"]
 
 [deps]

--- a/lib/OptimizationManopt/Project.toml
+++ b/lib/OptimizationManopt/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationManopt"
 uuid = "e57b7fff-7ee7-4550-b4f0-90e9476e9fb6"
 authors = ["Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "1.3.4"
+version = "1.3.5"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/OptimizationMetaheuristics/Project.toml
+++ b/lib/OptimizationMetaheuristics/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationMetaheuristics"
 uuid = "3aafef2f-86ae-4776-b337-85a36adf0b55"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 Metaheuristics = "bcdb8e00-2c21-11e9-3065-2b553b22f898"

--- a/lib/OptimizationMultistartOptimization/Project.toml
+++ b/lib/OptimizationMultistartOptimization/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationMultistartOptimization"
 uuid = "e4316d97-8bbb-4fd3-a7d8-3851d2a72823"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.7"
+version = "0.3.8"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 MultistartOptimization = "3933049c-43be-478e-a8bb-6e0f7fd53575"

--- a/lib/OptimizationNLPModels/Project.toml
+++ b/lib/OptimizationNLPModels/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationNLPModels"
 uuid = "064b21be-54cf-11ef-1646-cdfee32b588f"
-version = "1.3.3"
+version = "1.3.4"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]

--- a/lib/OptimizationNLopt/Project.toml
+++ b/lib/OptimizationNLopt/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationNLopt"
 uuid = "4e6fcdb7-1186-4e1f-a706-475e75c168bb"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.13"
+version = "0.3.14"
 
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"

--- a/lib/OptimizationNOMAD/Project.toml
+++ b/lib/OptimizationNOMAD/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationNOMAD"
 uuid = "2cab0595-8222-4775-b714-9828e6a9e01b"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 NOMAD = "02130f1c-4665-5b79-af82-ff1385104aa0"

--- a/lib/OptimizationODE/Project.toml
+++ b/lib/OptimizationODE/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationODE"
 uuid = "dfa73e59-e644-4d8a-bf84-188d7ecb34e4"
 authors = ["Paras Puneet Singh <paras.puneet2204@gmail.com>"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"

--- a/lib/OptimizationOptimJL/Project.toml
+++ b/lib/OptimizationOptimJL/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationOptimJL"
 uuid = "36348300-93cb-4f02-beb5-3c3902f8871e"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.4.16"
+version = "0.4.17"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/lib/OptimizationPRIMA/Project.toml
+++ b/lib/OptimizationPRIMA/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationPRIMA"
 uuid = "72f8369c-a2ea-4298-9126-56167ce9cbc2"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.10"
+version = "0.3.11"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 PRIMA = "0a7d04aa-8ac2-47b3-b7a7-9dbd6ad661ed"

--- a/lib/OptimizationPolyalgorithms/Project.toml
+++ b/lib/OptimizationPolyalgorithms/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationPolyalgorithms"
 uuid = "500b13db-7e66-49ce-bda4-eed966be6282"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 OptimizationOptimisers = "42dfb2eb-d2b4-4451-abcd-913932933ac1"

--- a/lib/OptimizationPyCMA/Project.toml
+++ b/lib/OptimizationPyCMA/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationPyCMA"
 uuid = "fb0822aa-1fe5-41d8-99a6-e7bf6c238d3b"
 authors = ["Maximilian Pochapski <67759684+mxpoch@users.noreply.github.com>"]
-version = "1.3.3"
+version = "1.3.4"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"

--- a/lib/OptimizationSciPy/Project.toml
+++ b/lib/OptimizationSciPy/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationSciPy"
 uuid = "cce07bd8-c79b-4b00-aee8-8db9cce22837"
 authors = ["Aditya Pandey <adityapand3y666@gmail.com> and contributors"]
-version = "0.4.8"
+version = "0.4.9"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"

--- a/lib/OptimizationSophia/Project.toml
+++ b/lib/OptimizationSophia/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationSophia"
 uuid = "892fee11-dca1-40d6-b698-84ba0d87399a"
 authors = ["paramthakkar123 <paramthakkar864@gmail.com>"]
-version = "1.3.3"
+version = "1.3.4"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/lib/OptimizationSpeedMapping/Project.toml
+++ b/lib/OptimizationSpeedMapping/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationSpeedMapping"
 uuid = "3d669222-0d7d-4eb9-8a9f-d8528b0d9b91"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.2.7"
+version = "0.2.8"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 SpeedMapping = "f1835b91-879b-4a3f-a438-e4baacf14412"

--- a/lib/SimpleOptimization/Project.toml
+++ b/lib/SimpleOptimization/Project.toml
@@ -1,5 +1,5 @@
 name = "SimpleOptimization"
-version = "1.2.3"
+version = "1.2.4"
 uuid = "510db2f7-4254-4e34-bbda-04240c91ca8f"
 authors = ["Utkarsh <rajpututkarsh530@gmail.com> and contributors"]
 


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `OptimizationBase` | 5.2.4 | 5.2.3 | skips over unregistered versions |
| `Optimization` | 5.6.5 | 5.6.6 | unreleased changes with no version bump |
| `OptimizationAuglag` | 2.0.2 | 2.0.3 | unreleased changes with no version bump |
| `OptimizationBBO` | 0.4.9 | 0.4.10 | unreleased changes with no version bump |
| `OptimizationCMAEvolutionStrategy` | 0.3.10 | 0.3.11 | unreleased changes with no version bump |
| `OptimizationEvolutionary` | 0.4.11 | 0.4.12 | unreleased changes with no version bump |
| `OptimizationGCMAES` | 0.3.10 | 0.3.11 | unreleased changes with no version bump |
| `OptimizationLBFGSB` | 1.4.3 | 1.4.4 | unreleased changes with no version bump |
| `OptimizationMOI` | 1.3.3 | 1.3.4 | unreleased changes with no version bump |
| `OptimizationMadNLP` | 2.2.2 | 2.2.3 | unreleased changes with no version bump |
| `OptimizationManopt` | 1.3.4 | 1.3.5 | unreleased changes with no version bump |
| `OptimizationMetaheuristics` | 0.3.8 | 0.3.9 | unreleased changes with no version bump |
| `OptimizationMultistartOptimization` | 0.3.7 | 0.3.8 | unreleased changes with no version bump |
| `OptimizationNLPModels` | 1.3.3 | 1.3.4 | unreleased changes with no version bump |
| `OptimizationNLopt` | 0.3.13 | 0.3.14 | unreleased changes with no version bump |
| `OptimizationNOMAD` | 0.3.8 | 0.3.9 | unreleased changes with no version bump |
| `OptimizationODE` | 0.1.8 | 0.1.9 | unreleased changes with no version bump |
| `OptimizationOptimJL` | 0.4.16 | 0.4.17 | unreleased changes with no version bump |
| `OptimizationPRIMA` | 0.3.10 | 0.3.11 | unreleased changes with no version bump |
| `OptimizationPolyalgorithms` | 0.3.8 | 0.3.9 | unreleased changes with no version bump |
| `OptimizationPyCMA` | 1.3.3 | 1.3.4 | unreleased changes with no version bump |
| `OptimizationSciPy` | 0.4.8 | 0.4.9 | unreleased changes with no version bump |
| `OptimizationSophia` | 1.3.3 | 1.3.4 | unreleased changes with no version bump |
| `OptimizationSpeedMapping` | 0.2.7 | 0.2.8 | unreleased changes with no version bump |
| `SimpleOptimization` | 1.2.3 | 1.2.4 | unreleased changes with no version bump |


## Why

Each `to` is the next sequential version after what is currently registered in
General. Versions that skip an unregistered version are rejected by AutoMerge's
sequential version number guideline, so they can never be registered as-is;
packages with unreleased changes and no bump cannot be registered at all.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).