### PR TITLE
Recognize explicit second-order AD inside AutoSparse

### DIFF
--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.2.4"
+version = "5.2.5"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]

--- a/lib/OptimizationBase/src/cache.jl
+++ b/lib/OptimizationBase/src/cache.jl
@@ -74,6 +74,7 @@ function OptimizationCache(
 
     if !(
             prob.f.adtype isa DifferentiationInterface.SecondOrder ||
+                prob.f.adtype isa AutoSparse{<:DifferentiationInterface.SecondOrder} ||
                 prob.f.adtype isa AutoZygote
         ) &&
             (

--- a/lib/OptimizationBase/test/core_tests.jl
+++ b/lib/OptimizationBase/test/core_tests.jl
@@ -5,5 +5,6 @@ using Test
     include("matrixvalued.jl")
     include("solver_missing_error_messages.jl")
     include("lag_h_sigma_zero_test.jl")
+    include("second_order_warning_test.jl")
     include("solve_internals_test.jl")
 end

--- a/lib/OptimizationBase/test/second_order_warning_test.jl
+++ b/lib/OptimizationBase/test/second_order_warning_test.jl
@@ -1,0 +1,23 @@
+using DifferentiationInterface: SecondOrder
+using ForwardDiff
+
+struct ExactHessianOptimizer end
+
+SciMLBase.requireshessian(::ExactHessianOptimizer) = true
+
+@testset "explicit sparse second-order AD" begin
+    objective(x, p) = sum(abs2, x)
+    sparse_second_order = AutoSparse(
+        SecondOrder(AutoForwardDiff(), AutoForwardDiff())
+    )
+    explicit_f = OptimizationFunction(objective, sparse_second_order)
+    explicit_prob = OptimizationProblem(explicit_f, [1.0, 1.0])
+
+    @test_nowarn OptimizationCache(explicit_prob, ExactHessianOptimizer())
+
+    implicit_f = OptimizationFunction(objective, AutoSparse(AutoForwardDiff()))
+    implicit_prob = OptimizationProblem(implicit_f, [1.0, 1.0])
+    @test_logs (:warn, r"missing_second_order_ad") match_mode = :any OptimizationCache(
+        implicit_prob, ExactHessianOptimizer()
+    )
+end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Problem

`OptimizationCache` warns that second-order AD is missing when an optimizer requires Hessians even if the user explicitly supplied `AutoSparse(SecondOrder(...))`. The sparse differentiation path already understands and preserves this representation, so the warning is incorrect.

This became visible in the BoundaryValueDiffEqMIRK downgrade lane after OptimizationIpopt 1.3 moved to the shared `OptimizationCache`.

## Change

- Recognize `AutoSparse{<:SecondOrder}` as explicit second-order AD.
- Add a regression test proving the explicit sparse backend is warning-free while `AutoSparse(AutoForwardDiff())` still emits `missing_second_order_ad`.
- Bump OptimizationBase from 5.2.4 to 5.2.5.

## Local verification

- `GROUP=OptimizationBase julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
  - `Core | 54 passed / 54 total`
  - `OptimizationBase tests passed`
- Runic 1.7.0: `--check .` passed.
