### PR TITLE
Correct OptimizationBase to the next sequential release

### DIFF
--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.2.4"
+version = "5.2.3"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

`OptimizationBase` carries `5.2.4` on master, which jumps over the unregistered `5.2.3` relative to the latest registered release `5.2.2`. AutoMerge rejects this under the [sequential version number guideline](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/), so `OptimizationBase` cannot currently register — and because 24 sibling subpackages depend on it, nothing else in this repo can register either.

| Package | master | corrected | registered |
| --- | --- | --- | --- |
| OptimizationBase | 5.2.4 | **5.2.3** | 5.2.2 |

One line, one file. `5.2.3` was never released, so no published history is lost.

### No compat bound is invalidated

Lowering a version can make a sibling `[compat]` bound unsatisfiable. Every in-repo bound on `OptimizationBase` is either `"5"` or `"5.1"`, both of which `5.2.3` still satisfies, so no dependent becomes uninstallable and no bound needs to move here.

### Context

Found while sweeping SciML for packages whose released state disagrees with master. The other 24 packages in this repo are at exactly their registered version with unreleased `src` changes, so they need ordinary version bumps rather than corrections — that is a separate PR, and it should land after this one so `OptimizationBase` registers first.