### PR TITLE
Fix parameterized sparse constraint Jacobians in Ipopt

### DIFF
--- a/lib/OptimizationIpopt/src/evaluator.jl
+++ b/lib/OptimizationIpopt/src/evaluator.jl
@@ -119,10 +119,13 @@ function eval_constraint_jacobian(evaluator::IpoptEvaluator, j, x)
         )
     end
     J = evaluator.J
-    if _accepts_live_p(evaluator)
-        evaluator.cache.f.cons_j(J, x, evaluator.cache.p)
+    cons_j = evaluator.cache.f.cons_j
+    p = evaluator.cache.p
+    # Sparse instantiation can capture `p` in a two-argument `cons_j` wrapper.
+    if _accepts_live_p(evaluator) && applicable(cons_j, J, x, p)
+        cons_j(J, x, p)
     else
-        evaluator.cache.f.cons_j(J, x)
+        cons_j(J, x)
     end
     if J isa SparseMatrixCSC
         nnz = nonzeros(J)

--- a/lib/OptimizationIpopt/test/core_tests.jl
+++ b/lib/OptimizationIpopt/test/core_tests.jl
@@ -71,6 +71,41 @@ end
     end
 end
 
+@testset "sparse explicit constraint Jacobian with parameters" begin
+    objective(x, p) = (x[1] - p[1])^2 + x[2]^2
+
+    function gradient!(G, x, p)
+        G[1] = 2 * (x[1] - p[1])
+        G[2] = 2 * x[2]
+        return
+    end
+
+    function constraints!(res, x, p)
+        res[1] = x[1] + x[2] - p[1]
+        return
+    end
+
+    function constraint_jacobian!(J, x, p)
+        J[1, 1] = 1
+        J[1, 2] = 1
+        return
+    end
+
+    f = OptimizationFunction(
+        objective,
+        AutoSparse(AutoForwardDiff());
+        grad = gradient!,
+        cons = constraints!,
+        cons_j = constraint_jacobian!,
+        cons_jac_prototype = sparse([1, 1], [1, 2], [1.0, 1.0], 1, 2)
+    )
+    prob = OptimizationProblem(f, [0.0, 0.0], [1.0]; lcons = [0.0], ucons = [0.0])
+    sol = solve(prob, IpoptOptimizer(hessian_approximation = "limited-memory"))
+
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u ≈ [1.0, 0.0] atol = 1.0e-6
+end
+
 include("additional_tests.jl")
 include("advanced_features.jl")
 include("problem_types.jl")


### PR DESCRIPTION
## Summary

Fix `OptimizationIpopt.eval_constraint_jacobian` to pass the live cache parameter only when the instantiated `cons_j` closure accepts it. `OptimizationBase` sparse instantiation captures parameters for a supplied `cons_j`, yielding a two-argument closure.

This fixes the clean-master `BoundaryValueDiffEqMIRK` SciMLStructures/Ipopt failure without changing BoundaryValueDiffEq or #577.

## Baseline trace

- `BoundaryValueDiffEq` clean master (`219b5021`), Julia 1.12, current resolver: the MIRK Core test errors in `OptimizationIpopt.eval_constraint_jacobian` because a two-argument instantiated `cons_j` is called with `(J, x, p)`.
- A/B source check using the same constrained sparse-Jacobian problem and current resolver: parent `3b0cff7a3` of `be6fbd279` passes; the current evaluator path fails pre-fix; this branch passes.

## Tests

- `OPTIMIZATION_TEST_GROUP=Core julia +1.12 --project=lib/OptimizationIpopt -e "using Pkg; Pkg.develop(path = \"lib/OptimizationBase\"); Pkg.test()"`
  - 127 passed, 1 pre-existing broken, 0 failures/errors
- `Runic --check --diff --quiet`
- `git diff --check`

Ignore until reviewed by @ChrisRackauckas.