### PR TITLE
Bump SimpleOptimization to 2.0.0 for release

### DIFF
--- a/lib/SimpleOptimization/Project.toml
+++ b/lib/SimpleOptimization/Project.toml
@@ -1,5 +1,5 @@
 name = "SimpleOptimization"
-version = "1.4.0"
+version = "2.0.0"
 uuid = "510db2f7-4254-4e34-bbda-04240c91ca8f"
 authors = ["Utkarsh <rajpututkarsh530@gmail.com> and contributors"]
 


### PR DESCRIPTION
Version bumps only -- no source changes.

Each package below has `src/` changes since its last registered version (verified by comparing the registry's recorded `git-tree-sha1` for that version against the current tree), but its `Project.toml` version still equals the registered one, so there is nothing to register.

Increment is minor, which is a valid standard increment under the General [sequential version number](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) guideline.

- SimpleOptimization 1.4.0 -> 2.0.0