### PR TITLE
Add lag_hess_structure: canonical COO enumeration for the vector lag_h

### DIFF
--- a/docs/src/API/optimization_function.md
+++ b/docs/src/API/optimization_function.md
@@ -3,4 +3,5 @@
 ```@docs
 SciMLBase.OptimizationFunction
 OptimizationBase.instantiate_function
+OptimizationBase.lag_hess_structure
 ```

--- a/lib/OptimizationBase/src/OptimizationBase.jl
+++ b/lib/OptimizationBase/src/OptimizationBase.jl
@@ -55,6 +55,9 @@ export ObjSense, MaxSense, MinSense
 export allowsbounds, requiresbounds, allowsconstraints, requiresconstraints,
     allowscallback, requiresgradient, requireshessian,
     requiresconsjac, requiresconshess
+# Canonical (rows, cols) enumeration of the vector-form lag_h write order;
+# solver wrappers must derive their declared Hessian structure from this.
+export lag_hess_structure
 
 using FastClosures
 

--- a/lib/OptimizationBase/src/function.jl
+++ b/lib/OptimizationBase/src/function.jl
@@ -277,3 +277,28 @@ function instantiate_function(
     adpkg = adtypestr[strtind:lastidx]
     throw(ArgumentError("The passed automatic differentiation backend choice is not available. Please load the corresponding AD package $adpkg."))
 end
+
+"""
+    lag_hess_structure(prototype::SparseMatrixCSC) -> (rows, cols)
+
+The canonical coordinates of the entries that the vector-form Lagrangian
+Hessian callback `lag_h(h, θ, σ, λ[, p])` writes, in the exact order it
+writes them. Solver wrappers that declare a sparse Hessian structure and
+fill it from the vector `lag_h` MUST derive their structure with this
+function — entry `k` of the value buffer corresponds to
+`(rows[k], cols[k])`. Wrappers whose convention requires lower-triangle
+coordinates (e.g. NLPModels) mirror each `(i, j)` to `(j, i)`; the
+mirrored sequence is still in `lag_h`'s value order.
+
+The write order is: the upper-triangle entries (`i ≤ j`) of the sparse
+Lagrangian Hessian prototype, enumerated in `findnz` (CSC, column-major)
+order. This order is part of the public API contract of `lag_h` and is
+frozen: changing it silently breaks every consumer that declared a
+structure against it.
+"""
+function lag_hess_structure(prototype::SparseMatrixCSC)
+    rows, cols, _ = findnz(prototype)
+    mask = rows .<= cols
+
+    return rows[mask], cols[mask]
+end

--- a/lib/OptimizationIpopt/src/evaluator.jl
+++ b/lib/OptimizationIpopt/src/evaluator.jl
@@ -143,8 +143,12 @@ function hessian_lagrangian_structure(evaluator::IpoptEvaluator)
     f = evaluator.cache.f
     lagh = f.lag_h !== nothing
     if f.lag_hess_prototype isa SparseMatrixCSC
-        rows, cols, _ = findnz(f.lag_hess_prototype)
-        return Tuple{Int, Int}[(i, j) for (i, j) in zip(rows, cols) if i <= j]
+        # Ipopt accepts either triangle; what matters is that the declared
+        # structure enumerates entries in the exact order the vector-form
+        # lag_h writes values. Derive it from the canonical helper so the
+        # contract lives in one place (OptimizationBase.lag_hess_structure).
+        rows, cols = OptimizationBase.lag_hess_structure(f.lag_hess_prototype)
+        return Tuple{Int, Int}[(i, j) for (i, j) in zip(rows, cols)]
     end
     sparse_obj = evaluator.H isa SparseMatrixCSC
     sparse_constraints = all(H -> H isa SparseMatrixCSC, evaluator.cons_H)

--- a/lib/OptimizationMadNLP/test/core_tests.jl
+++ b/lib/OptimizationMadNLP/test/core_tests.jl
@@ -28,34 +28,46 @@ import SciMLBase
 end
 
 @testset "tutorial" begin
-    rosenbrock(x, p) = (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
-    x0 = zeros(2)
-    _p = [1.0, 1.0]
+    # 3 coupled variables on purpose: for a 2x2 pattern the upper- and
+    # lower-triangle CSC enumerations coincide (by symmetry), so a 2x2 test
+    # cannot detect a structure/value ordering mismatch. With three coupled
+    # columns the enumerations diverge from the third entry on.
+    rosenbrock3(x, p) = (1 - x[1])^2 + p[1] * (x[2] - x[1]^2)^2 + (x[3] - x[2])^2
+    x0 = [0.5, 0.5, 1.0]
+    _p = [10.0]
 
-    cons(res, x, p) = (res .= [x[1]^2 + x[2]^2, x[1] * x[2]])
+    cons(res, x, p) = (res .= [x[1]^2 + x[2]^2, x[1] * x[3]])
 
+    # The vector-form lag_h must write values in the canonical order of
+    # OptimizationBase.lag_hess_structure(lag_hess_prototype): the upper
+    # triangle (i <= j) in findnz/CSC order. For the dense 3x3 pattern that is
+    # (1,1), (1,2), (2,2), (1,3), (2,3), (3,3).
     function lagh(res, x, sigma, mu, p)
-        lH = sigma * [
-            2 + 8(x[1]^2) * p[2] - 4(x[2] - (x[1]^2)) * p[2] -4p[2] * x[1]
-            -4p[2] * x[1] 2p[2]
-        ] .+ [
-            2mu[1] mu[2]
-            mu[2] 2mu[1]
-        ]
-        # MadNLP uses lower triangle. For symmetric sparse([1 1; 1 1]), lower triangle has [1,1], [2,1], and [2,2]
-        res[1] = lH[1, 1]  # Position [1,1]
-        res[2] = lH[2, 1]  # Position [2,1] (off-diagonal)
-        res[3] = lH[2, 2]  # Position [2,2]
+        res[1] = sigma * (2 - 4p[1] * (x[2] - x[1]^2) + 8p[1] * x[1]^2) + 2mu[1] # H[1,1]
+        res[2] = sigma * (-4p[1] * x[1])                                         # H[1,2]
+        res[3] = sigma * (2p[1] + 2) + 2mu[1]                                    # H[2,2]
+        res[4] = mu[2]                                                           # H[1,3]
+        res[5] = sigma * (-2)                                                    # H[2,3]
+        res[6] = sigma * 2                                                       # H[3,3]
     end
-    lag_hess_prototype = sparse([1 1; 1 1])  # Symmetric sparse pattern for Hessian
+    lag_hess_prototype = sparse(ones(3, 3))  # dense symmetric 3x3 pattern
 
-    # Use SecondOrder AD for MadNLP
     ad = SecondOrder(ADTypes.AutoForwardDiff(), ADTypes.AutoZygote())
     optprob = OptimizationFunction(
-        rosenbrock, ad;
+        rosenbrock3, ad;
         cons = cons, lag_h = lagh, lag_hess_prototype
     )
-    prob = OptimizationProblem(optprob, x0, _p, lcons = [1.0, 0.5], ucons = [1.0, 0.5])
+    prob = OptimizationProblem(optprob, x0, _p, lcons = [1.0, 0.5], ucons = [1.0, Inf])
+
+    # Reference: same problem, derivatives fully from AD (no user lag_h).
+    # ForwardDiff-over-ForwardDiff: the Zygote-inner AD-only constrained path
+    # currently errors in OptimizationZygoteExt (closure arity), tracked
+    # separately from this ordering fix.
+    ad_ref = SecondOrder(ADTypes.AutoForwardDiff(), ADTypes.AutoForwardDiff())
+    optprob_ad = OptimizationFunction(rosenbrock3, ad_ref; cons = cons)
+    prob_ad = OptimizationProblem(optprob_ad, x0, _p, lcons = [1.0, 0.5], ucons = [1.0, Inf])
+    sol_ad = solve(prob_ad, MadNLPOptimizer())
+    @test SciMLBase.successful_retcode(sol_ad)
 
     opts = [
         MadNLPOptimizer(),
@@ -66,8 +78,9 @@ end
         sol = solve(prob, opt)
         @test SciMLBase.successful_retcode(sol)
 
-        # compare against Ipopt results
-        @test sol ≈ [0.7071678163428006, 0.7070457460302945] rtol = 1.0e-4
+        # A garbled structure/value ordering shows up as a different (or
+        # non-)optimum than the pure-AD reference.
+        @test sol.u ≈ sol_ad.u rtol = 1.0e-4
     end
 end
 
@@ -193,20 +206,21 @@ end
         # [1    0    2    0  ]
         # [0    1    0    0  ]
         #
-        # Lower triangle indices: [1,1], [3,1], [2,2], [4,2], [3,3]
-        # Total: 5 non-zero elements in lower triangle
+        # Canonical write order (OptimizationBase.lag_hess_structure of the
+        # prototype: upper triangle in findnz/CSC order):
+        # (1,1), (2,2), (1,3), (3,3), (2,4) — 5 stored entries.
 
         # Objective Hessian contribution
         res[1] = sigma * 2.0   # H[1,1] from x1^2
-        res[2] = sigma * 1.0   # H[3,1] from x1*x3
-        res[3] = sigma * 4.0   # H[2,2] from 2*x2^2
-        res[4] = sigma * 1.0   # H[4,2] from x2*x4
-        res[5] = sigma * 2.0   # H[3,3] from x3^2
+        res[2] = sigma * 4.0   # H[2,2] from 2*x2^2
+        res[3] = sigma * 1.0   # H[1,3] from x1*x3
+        res[4] = sigma * 2.0   # H[3,3] from x3^2
+        res[5] = sigma * 1.0   # H[2,4] from x2*x4
 
         # Constraint contributions
         # First constraint (x1+x2+x3+x4=4) has zero Hessian
         # Second constraint (x1*x3>=1) has d²c/dx1dx3 = 1
-        res[2] += mu[2] * 1.0  # Add to H[3,1]
+        res[3] += mu[2] * 1.0  # Add to H[1,3]
     end
 
     # Create sparse prototype with the correct structure

--- a/lib/OptimizationNLPModels/Project.toml
+++ b/lib/OptimizationNLPModels/Project.toml
@@ -19,6 +19,8 @@ OptimizationOptimJL = {path = "../OptimizationOptimJL"}
 [compat]
 SciMLTesting = "2.8"
 ADTypes = "1.18"
+DifferentiationInterface = "0.7"
+ForwardDiff = "0.10, 1"
 Ipopt = "1"
 NLPModels = "0.21"
 NLPModelsTest = "0.10"
@@ -37,6 +39,10 @@ julia = "1.10"
 
 [extras]
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
@@ -49,4 +55,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["SciMLTesting", "Test", "NLPModelsTest", "OptimizationOptimJL", "ReverseDiff", "Zygote", "Ipopt", "OptimizationMOI", "OptimizationLBFGSB", "SafeTestsets", "Pkg"]
+test = ["SciMLTesting", "Test", "NLPModelsTest", "OptimizationOptimJL", "ReverseDiff", "Zygote", "Ipopt", "OptimizationMOI", "OptimizationLBFGSB", "SafeTestsets", "Pkg", "ForwardDiff", "DifferentiationInterface", "ADTypes", "SparseArrays"]

--- a/lib/OptimizationNLPModels/src/OptimizationNLPModels.jl
+++ b/lib/OptimizationNLPModels/src/OptimizationNLPModels.jl
@@ -147,13 +147,18 @@ function NLPModelsAdaptor(
     hess_proto = ncon > 0 ? cache.f.lag_hess_prototype : cache.f.hess_prototype
 
     if !isnothing(hess_proto) && hess_proto isa SparseMatrixCSC
-        I, J, _ = findnz(hess_proto)
-        # Keep only lower triangle
-        lower_mask = I .>= J
-        hess_rows = I[lower_mask]
-        hess_cols = J[lower_mask]
-        # Create a values buffer matching the number of lower triangle elements
-        hess_buffer = zeros(T, sum(lower_mask))
+        # The vector-form `lag_h(h, x, σ, λ)` fills `h` in the canonical order
+        # given by `OptimizationBase.lag_hess_structure` (upper triangle,
+        # findnz/CSC order). The structure declared here must enumerate the
+        # very same entries in the very same order, otherwise the values land
+        # on the wrong indices. NLPModels' convention wants lower-triangle
+        # coordinates, so mirror each (i, j), i ≤ j entry to (j, i) — the
+        # mirrored sequence preserves the value order.
+        rows, cols = OptimizationBase.lag_hess_structure(hess_proto)
+        hess_rows = cols
+        hess_cols = rows
+        # Values buffer matching the number of stored entries
+        hess_buffer = zeros(T, length(rows))
     elseif !isnothing(hess_proto)
         # Dense Hessian
         n = size(hess_proto, 1)

--- a/lib/OptimizationNLPModels/test/core_tests.jl
+++ b/lib/OptimizationNLPModels/test/core_tests.jl
@@ -129,3 +129,83 @@ using Test
     @test sol_converted.retcode == sol_native.retcode
     @test sol_converted.u ≈ sol_native.u
 end
+
+@testset "sparse lag_h structure/value ordering (canonical contract)" begin
+    # Regression test for the COO ordering bug: the adaptor declared the
+    # lower triangle in CSC order while OptimizationBase's vector lag_h
+    # writes the upper triangle in CSC order — a different enumeration for
+    # any pattern with >= 3 coupled columns, so every off-diagonal value
+    # landed on a wrong index. A 2x2 pattern CANNOT catch this (the two
+    # enumerations coincide by symmetry); this problem has three coupled
+    # variables on purpose.
+    using SparseArrays
+    import ADTypes
+    import ForwardDiff
+    import DifferentiationInterface
+
+    obj(x, p) = (1 - x[1])^2 + 10.0 * (x[2] - x[1]^2)^2 + (x[3] - x[2])^2
+    cons(res, x, p) = (res .= [x[1]^2 + x[2]^2, x[1] * x[3]])
+    x0 = [0.4, -0.7, 1.3]
+    σ = 0.7
+    λ = [1.3, -2.1]
+
+    sparse_ad = ADTypes.AutoSparse(
+        DifferentiationInterface.SecondOrder(ADTypes.AutoForwardDiff(), ADTypes.AutoForwardDiff())
+    )
+    dense_ad = DifferentiationInterface.SecondOrder(ADTypes.AutoForwardDiff(), ADTypes.AutoForwardDiff())
+
+    f = OptimizationBase.OptimizationFunction(obj, sparse_ad; cons = cons)
+    inst = OptimizationBase.instantiate_function(
+        f, x0, sparse_ad, nothing, 2; lag_h = true, cons_j = true
+    )
+
+    fd = OptimizationBase.OptimizationFunction(obj, dense_ad; cons = cons)
+    inst_dense = OptimizationBase.instantiate_function(
+        fd, x0, dense_ad, nothing, 2; lag_h = true
+    )
+
+    # Independent dense reference Lagrangian Hessian
+    Href = zeros(3, 3)
+    inst_dense.lag_h(Href, x0, σ, λ)
+
+    proto = inst.lag_hess_prototype
+    @test proto isa SparseMatrixCSC
+
+    # 1. The canonical helper matches the order the vector lag_h writes.
+    rows, cols = OptimizationBase.lag_hess_structure(proto)
+    h = zeros(length(rows))
+    inst.lag_h(h, x0, σ, λ)
+    for k in eachindex(h)
+        @test h[k] ≈ Href[rows[k], cols[k]] atol = 1.0e-10
+    end
+
+    # 2. Guard the test's power: on this pattern the canonical (mirrored)
+    # enumeration must differ from the naive lower-triangle CSC enumeration
+    # that caused the bug — otherwise this test could not detect it.
+    I_, J_, _ = findnz(proto)
+    lower_mask = I_ .>= J_
+    @test !(cols == I_[lower_mask] && rows == J_[lower_mask])
+
+    # 3. Adaptor end-to-end: declared structure + coord values agree with the
+    # dense reference entry-wise.
+    meta = NLPModels.NLPModelMeta(
+        3; ncon = 2, x0 = x0, y0 = zeros(2),
+        lcon = [1.0, 0.5], ucon = [1.0, Inf],
+        nnzj = nnz(inst.cons_jac_prototype), nnzh = length(rows), minimize = true
+    )
+    cache_like = (f = inst, p = nothing, lcons = [1.0, 0.5], ucons = [1.0, Inf])
+    nlp = OptimizationNLPModels.NLPModelsAdaptor(cache_like, meta, NLPModels.Counters())
+
+    srows = zeros(Int, length(rows))
+    scols = zeros(Int, length(rows))
+    NLPModels.hess_structure!(nlp, srows, scols)
+    # NLPModels convention: lower-triangle coordinates (mirrored canonical)
+    @test all(srows .>= scols)
+    @test srows == cols && scols == rows
+
+    vals = zeros(length(rows))
+    NLPModels.hess_coord!(nlp, x0, λ, vals; obj_weight = σ)
+    for k in eachindex(vals)
+        @test vals[k] ≈ Href[srows[k], scols[k]] atol = 1.0e-10
+    end
+end


### PR DESCRIPTION
## The bug this fixes

The vector-form `lag_h(h, θ, σ, λ)` that OptimizationBase generates fills `h` with the **upper-triangle** entries of the sparse Lagrangian Hessian in `findnz` (CSC, column-major) order. That order was an *implicit* contract that each solver wrapper re-derived independently:

- `OptimizationIpopt` derived its declared structure with the same mask and order — correct.
- `OptimizationNLPModels`' `NLPModelsAdaptor` declared the **lower** triangle in CSC order — a *different enumeration* for any symmetric pattern with ≥ 3 coupled columns. Every off-diagonal Hessian value landed on a wrong index, and MadNLP silently optimized with garbled curvature (found while benchmarking a 6471-nnz optimal-control NLP: the misplaced entries turned a convergent solve into 300 iterations of wandering).

Why tests never caught it: the existing MadNLP test used a 2×2 pattern, where the two enumerations coincide by symmetry — structurally incapable of detecting the mismatch — and assertions compared converged solutions, never derivative values.

## The change

- **OptimizationBase**: export `lag_hess_structure(prototype::SparseMatrixCSC) -> (rows, cols)`, the canonical coordinates in exactly the order the vector `lag_h` writes, documented as frozen public API. Wrappers derive their structure from this instead of re-deriving their own enumeration.
- **OptimizationIpopt**: use the helper (behavior identical — pure refactor; the derivation now lives in one place).
- **OptimizationNLPModels**: use the helper, mirroring each `(i, j), i ≤ j` to `(j, i)` so the declared coordinates satisfy the NLPModels lower-triangle convention while preserving the value order (mirrored upper-CSC ≡ lower-CSR: same entries, same sequence).
- **Tests**: replace the 2×2 tutorial problem with an ordering-sensitive 3-variable problem checked against a pure-AD reference; fix the 4×4 test's hand-written `lag_h` to the canonical order; add an entry-wise structure/value regression test in OptimizationNLPModels against an independent dense-AD Lagrangian Hessian (plus a guard asserting the pattern actually distinguishes the two enumerations).

## Verification

23/23 in a dedicated suite: helper unit (exact expected coordinates on a 3×3 pattern), entry-wise value-at-coordinate checks through the AutoSparse DI path, adaptor end-to-end via `hess_structure!`/`hess_coord!`, and cross-solver consistency — the same hand-written canonical-order `lag_h` reaches the same optimum through both `IpoptOptimizer` and `MadNLPOptimizer` (previously impossible: the two wrappers demanded contradictory value orders).

## Compatibility note

User-supplied sparse vector-form `lag_h` callbacks that wrote values in the adaptor's old lower-CSC order (as the in-repo 4×4 test did) must switch to the canonical order. Such callbacks could never have been correct on both Ipopt and MadNLP simultaneously; this PR makes one order valid everywhere.

Known separate issue (not addressed here): AD-only constrained problems with `SecondOrder(_, AutoZygote)` error in `OptimizationZygoteExt` (closure arity) on the MadNLP path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gm49JbHkX5UC15UrQXveFh