### PR TITLE
Fix the wrapper reexport floors and surface

### DIFF
--- a/docs/src/optimization_packages/manopt.md
+++ b/docs/src/optimization_packages/manopt.md
@@ -26,7 +26,7 @@ The following methods are available for the `OptimizationManopt` package:
   - `CMAESOptimizer`: Corresponds to the [`cma_es`](https://manoptjl.org/stable/solvers/cma_es/) method in Manopt.
   - `ConvexBundleOptimizer`: Corresponds to the [`convex_bundle_method`](https://manoptjl.org/stable/solvers/convex_bundle_method/) method in Manopt.
   - `FrankWolfeOptimizer`: Corresponds to the [`FrankWolfe`](https://manoptjl.org/stable/solvers/FrankWolfe/) method in Manopt.
-  - `AdaptiveRegularizationCubicOptimizer`: Corresponds to the [`adaptive_regularization_with_cubics`](https://manoptjl.org/stable/solvers/adaptive-regularization-with-cubics/) method in Manopt.
+  - `AdaptiveRegularizationCubicOptimizer`: Corresponds to the [`adaptive_regularization_with_cubics`](https://manoptjl.org/stable/solvers/adaptive_regularization_with_cubics/) method in Manopt.
   - `TrustRegionsOptimizer`: Corresponds to the [`trust_regions`](https://manoptjl.org/stable/solvers/trust_regions/) method in Manopt.
 
 ```@docs

--- a/docs/src/optimization_packages/multistartoptimization.md
+++ b/docs/src/optimization_packages/multistartoptimization.md
@@ -18,7 +18,7 @@ Pkg.add("OptimizationMultistartOptimization");
 !!! note
     
 
-You also need to load the relevant subpackage for the local method of your choice, for example if you plan to use one of the NLopt.jl's optimizers, you'd install and load OptimizationNLopt as described in the [NLopt.jl](@ref)'s section.
+You also need to load the relevant subpackage for the local method of your choice, for example if you plan to use one of the NLopt.jl's optimizers, you'd install and load OptimizationNLopt as described in the [NLopt.jl](@ref nlopt)'s section.
 
 ## Global Optimizer
 

--- a/docs/src/optimization_packages/optimisers.md
+++ b/docs/src/optimization_packages/optimisers.md
@@ -22,8 +22,6 @@ package only re-exports them.
   - Gradient descent rules: `Descent`, `Momentum`, `Nesterov`, `Rprop`
   - Adaptive rules: `RMSProp`, `Adam`, `RAdam`, `AdaMax`, `OAdam`, `AdaGrad`,
     `AdaDelta`, `AMSGrad`, `NAdam`, `AdamW`, `AdaBelief`, `Lion`
-  - Legacy all-caps spellings kept for compatibility: `ADAM`, `ADAMW`, `RADAM`,
-    `OADAM`, `NADAM`, `ADAGrad`, `ADADelta`
   - Gradient modifiers and combinators: `ClipGrad`, `ClipNorm`, `WeightDecay`,
     `SignDecay`, `AccumGrad`, `OptimiserChain`
   - The `Optimisers` module itself; the rule supertype is `Optimisers.AbstractRule`
@@ -116,23 +114,23 @@ Anything else from Optimisers.jl must be imported from Optimisers directly.
         
           * `η = 0.001`
           * `β::Tuple = (0.9, 0.999)`
-  - [`Optimisers.ADAGrad`](https://fluxml.ai/Optimisers.jl/dev/api/#Optimisers.ADAGrad): **ADAGrad optimizer**
+  - [`Optimisers.AdaGrad`](https://fluxml.ai/Optimisers.jl/dev/api/#Optimisers.AdaGrad): **AdaGrad optimizer**
     
-      + `solve(problem, ADAGrad(η))`
+      + `solve(problem, AdaGrad(η))`
     
       + `η` is the learning rate
       + Defaults:
         
           * `η = 0.1`
-  - [`Optimisers.ADADelta`](https://fluxml.ai/Optimisers.jl/dev/api/#Optimisers.ADADelta): **ADADelta optimizer**
+  - [`Optimisers.AdaDelta`](https://fluxml.ai/Optimisers.jl/dev/api/#Optimisers.AdaDelta): **AdaDelta optimizer**
     
-      + `solve(problem, ADADelta(ρ))`
+      + `solve(problem, AdaDelta(ρ))`
     
       + `ρ` is the gradient decay factor
       + Defaults:
         
           * `ρ = 0.9`
-  - [`Optimisers.AMSGrad`](https://fluxml.ai/Optimisers.jl/dev/api/#Optimisers.ADAGrad): **AMSGrad optimizer**
+  - [`Optimisers.AMSGrad`](https://fluxml.ai/Optimisers.jl/dev/api/#Optimisers.AMSGrad): **AMSGrad optimizer**
     
       + `solve(problem, AMSGrad(η, β::Tuple))`
     
@@ -164,9 +162,9 @@ Anything else from Optimisers.jl must be imported from Optimisers directly.
           * `η = 0.001`
           * `β::Tuple = (0.9, 0.999)`
           * `decay = 0`
-  - [`Optimisers.ADABelief`](https://fluxml.ai/Optimisers.jl/dev/api/#Optimisers.ADABelief): **ADABelief variant of Adam**
+  - [`Optimisers.AdaBelief`](https://fluxml.ai/Optimisers.jl/dev/api/#Optimisers.AdaBelief): **AdaBelief variant of Adam**
     
-      + `solve(problem, ADABelief(η, β::Tuple))`
+      + `solve(problem, AdaBelief(η, β::Tuple))`
     
       + `η` is the learning rate
       + `β::Tuple` is the decay of momentums

--- a/lib/OptimizationMetaheuristics/Project.toml
+++ b/lib/OptimizationMetaheuristics/Project.toml
@@ -20,7 +20,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
 julia = "1.10"
-Metaheuristics = "3.3"
+Metaheuristics = "3.5"
 OptimizationBase = "5"
 Pkg = "1"
 Random = "1.10"

--- a/lib/OptimizationOptimisers/src/OptimizationOptimisers.jl
+++ b/lib/OptimizationOptimisers/src/OptimizationOptimisers.jl
@@ -8,10 +8,9 @@ using Optimisers
 # `@reexport`, which also exported `Optimisers.init`/`update`/`setup` — and
 # `Optimisers.init` shadowing `SciMLBase.init` broke the cache interface for anyone
 # loading both. Everything stays owned and documented upstream in Optimisers.jl.
-using Optimisers: ADADelta, ADAGrad, ADAM, ADAMW, AMSGrad, AbstractRule, AccumGrad,
-    AdaBelief, AdaDelta, AdaGrad, AdaMax, Adam, AdamW, ClipGrad, ClipNorm, Descent,
-    Lion, Momentum, NADAM, NAdam, Nesterov, OADAM, OAdam, OptimiserChain, RADAM,
-    RAdam, RMSProp, Rprop, SignDecay, WeightDecay
+using Optimisers: AMSGrad, AbstractRule, AccumGrad, AdaBelief, AdaDelta, AdaGrad,
+    AdaMax, Adam, AdamW, ClipGrad, ClipNorm, Descent, Lion, Momentum, NAdam, Nesterov,
+    OAdam, OptimiserChain, RAdam, RMSProp, Rprop, SignDecay, WeightDecay
 # Not re-exported: the optimization API comes from `Optimization`/`OptimizationBase`,
 # which the user loads directly. This package's public surface is its own solvers.
 using OptimizationBase
@@ -24,10 +23,9 @@ export Optimisers
 # own `init`/`setup`/`update`/`apply!`/`destructure` interface is deliberately not
 # re-surfaced — Optimization.jl drives the rules itself, and `init` collides with the
 # SciML `init`. Reach those as `Optimisers.setup` etc.
-export ADADelta, ADAGrad, ADAM, ADAMW, AMSGrad, AccumGrad,
-    AdaBelief, AdaDelta, AdaGrad, AdaMax, Adam, AdamW, ClipGrad, ClipNorm, Descent,
-    Lion, Momentum, NADAM, NAdam, Nesterov, OADAM, OAdam, OptimiserChain, RADAM,
-    RAdam, RMSProp, Rprop, SignDecay, WeightDecay
+export AMSGrad, AccumGrad, AdaBelief, AdaDelta, AdaGrad, AdaMax, Adam, AdamW,
+    ClipGrad, ClipNorm, Descent, Lion, Momentum, NAdam, Nesterov, OAdam,
+    OptimiserChain, RAdam, RMSProp, Rprop, SignDecay, WeightDecay
 
 SciMLBase.has_init(opt::AbstractRule) = true
 SciMLBase.requiresgradient(opt::AbstractRule) = true

--- a/lib/OptimizationOptimisers/test/qa/qa.jl
+++ b/lib/OptimizationOptimisers/test/qa/qa.jl
@@ -8,11 +8,9 @@ using Optimisers
 # Kept in sync with the reexport `export` block in src/OptimizationOptimisers.jl: the
 # Optimisers rule names `using OptimizationOptimisers` is expected to bring into scope.
 const OPTIMISERS_REEXPORTS = (
-    :ADADelta, :ADAGrad, :ADAM, :ADAMW, :AMSGrad, :AccumGrad,
-    :AdaBelief, :AdaDelta, :AdaGrad, :AdaMax, :Adam, :AdamW, :ClipGrad, :ClipNorm,
-    :Descent, :Lion, :Momentum, :NADAM, :NAdam, :Nesterov, :OADAM, :OAdam,
-    :OptimiserChain, :Optimisers, :RADAM, :RAdam, :RMSProp, :Rprop, :SignDecay,
-    :WeightDecay,
+    :AMSGrad, :AccumGrad, :AdaBelief, :AdaDelta, :AdaGrad, :AdaMax, :Adam, :AdamW,
+    :ClipGrad, :ClipNorm, :Descent, :Lion, :Momentum, :NAdam, :Nesterov, :OAdam,
+    :OptimiserChain, :Optimisers, :RAdam, :RMSProp, :Rprop, :SignDecay, :WeightDecay,
 )
 
 # ExplicitImports findings, all tracked against SciML/Optimization.jl:
@@ -45,12 +43,6 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:OptimizationState, :OptimizationStats, :__init, :__solve, :_check_and_convert_maxiters, :allowscallback, :allowsfg, :isa_dataiterator, :requiresgradient)),
     ),
     ei_broken = (:no_implicit_imports,),
-    # Optimisers.jl gives its legacy all-caps aliases no docstring of their own; they
-    # are kept public here so code written against `ADAM(0.01)` keeps working. The
-    # docstring obligation is Optimisers.jl's.
-    api_docs_kwargs = (;
-        ignore = (:ADADelta, :ADAGrad, :ADAM, :ADAMW, :NADAM, :OADAM, :RADAM),
-    ),
     reexports_allow = OPTIMISERS_REEXPORTS,
 )
 


### PR DESCRIPTION
This stacked PR supplies the minimal compat and surface corrections found while validating the parent reexport restoration.

Parent PR: https://github.com/SciML/Optimization.jl/pull/1315

Ignore this PR until reviewed by @ChrisRackauckas.

## What changes

- Raises only `OptimizationMetaheuristics`’s Metaheuristics floor, from 3.3 to 3.5. `RDEx` is first present in registered Metaheuristics 3.5.0.
- Removes `ADADelta`, `ADAGrad`, `ADAM`, `ADAMW`, `NADAM`, `OADAM`, and `RADAM` from the proposed Optimisers reexport list. They were not exported by Optimisers 0.4.2 when the blanket reexport was stripped, so the blanket reexport never exposed them. The corresponding QA exception is removed, and the docs use the public mixed-case names.
- Repairs the branch-owned Manopt URL, the NLopt cross-reference, the AMSGrad anchor. Both corrected external URLs return HTTP 200.

## Registered-tag floor audit

I cloned each owner afresh, mapped every restored name across every registered non-yanked tag, chose the maximum introduction version, and checked that no later registered version drops a required name.

| Owner | Minimal continuous floor for this surface | Declared floor/result |
|---|---:|---|
| Metaheuristics | 3.5.0 (`RDEx`) | raised to 3.5 |
| Optim | 0.15.3 | existing 2 is sufficient |
| Optimisers | 0.3.2 (`SignDecay`) | existing 0.4.2 is sufficient after pruning the seven never-reexported aliases |
| NLopt | 0.5.0 | existing 1.1 is sufficient |
| NLPModels | 0.6.0 | existing 0.21 is sufficient |
| Manopt | no name floor: the wrapper reexports only the module binding | no change |

The Metaheuristics scan covered all 35 registered versions with zero parse failures. Metaheuristics 3.4.2 produces `UndefVarError: RDEx not defined in OptimizationMetaheuristics`; 3.5.0 loads and `OptimizationMetaheuristics.RDEx === Metaheuristics.RDEx`.

## Local verification

- `GROUP=OptimizationMetaheuristics ... Pkg.test()` → Core 50/50.
- `GROUP=OptimizationMetaheuristics_QA ... Pkg.test()` → Quality Assurance 68 passed, 1 existing broken.
- `GROUP=OptimizationOptimisers ... Pkg.test()` → Core 39 passed, 1 existing broken.
- `GROUP=OptimizationOptimisers_QA ... Pkg.test()` → Quality Assurance 66 passed, 1 existing broken.
- `GROUP=QA ... Pkg.test()` → QA 20 passed, 1 existing broken.
- `JULIA_CONDAPKG_BACKEND=Null JULIA_PYTHONCALL_EXE=/usr/bin/python3 PYTHONPATH=<workspace cma target> ~/.juliaup/bin/julia +release --project=docs docs/make.jl` → exit 0 after doctests, cross-references, link checks, document checks, and HTML rendering.
- `~/.juliaup/bin/julia +release -m Runic --check <changed Julia files>`, `typos <all changed files>`, and `git diff --check` against this stacked delta → exit 0.
- `curl -L` → HTTP 200 for https://manoptjl.org/stable/solvers/adaptive_regularization_with_cubics/.

The system-Python settings for the docs run work around a local CondaPkg/Pixi environment defect: Pixi installed an incomplete Python 3.14 environment despite the declared exclusion, causing `init_fs_encoding` before Documenter started. No test or docs check was disabled. GPU, prerelease-Julia, and downstream lanes were not run locally.

This branch is based directly on the current upstream parent feature head `d27035de` and contains only the corrections above.

AI continuation: OpenAI Codex session ID 01a03a11-47c2-77e0-858b-167004f0b79c.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ