### PR TITLE
Fix the two docs errors failing the Documentation build

### DIFF
--- a/docs/src/optimization_packages/manopt.md
+++ b/docs/src/optimization_packages/manopt.md
@@ -26,7 +26,7 @@ The following methods are available for the `OptimizationManopt` package:
   - `CMAESOptimizer`: Corresponds to the [`cma_es`](https://manoptjl.org/stable/solvers/cma_es/) method in Manopt.
   - `ConvexBundleOptimizer`: Corresponds to the [`convex_bundle_method`](https://manoptjl.org/stable/solvers/convex_bundle_method/) method in Manopt.
   - `FrankWolfeOptimizer`: Corresponds to the [`FrankWolfe`](https://manoptjl.org/stable/solvers/FrankWolfe/) method in Manopt.
-  - `AdaptiveRegularizationCubicOptimizer`: Corresponds to the [`adaptive_regularization_with_cubics`](https://manoptjl.org/stable/solvers/adaptive-regularization-with-cubics/) method in Manopt.
+  - `AdaptiveRegularizationCubicOptimizer`: Corresponds to the [`adaptive_regularization_with_cubics`](https://manoptjl.org/stable/solvers/adaptive_regularization_with_cubics/) method in Manopt.
   - `TrustRegionsOptimizer`: Corresponds to the [`trust_regions`](https://manoptjl.org/stable/solvers/trust_regions/) method in Manopt.
 
 ```@docs

--- a/docs/src/optimization_packages/multistartoptimization.md
+++ b/docs/src/optimization_packages/multistartoptimization.md
@@ -18,7 +18,7 @@ Pkg.add("OptimizationMultistartOptimization");
 !!! note
     
 
-You also need to load the relevant subpackage for the local method of your choice, for example if you plan to use one of the NLopt.jl's optimizers, you'd install and load OptimizationNLopt as described in the [NLopt.jl](@ref)'s section.
+You also need to load the relevant subpackage for the local method of your choice, for example if you plan to use one of the NLopt.jl's optimizers, you'd install and load OptimizationNLopt as described in the [NLopt.jl](@ref nlopt)'s section.
 
 ## Global Optimizer
 


### PR DESCRIPTION
## Root cause

The [Documentation run on master](https://github.com/SciML/Optimization.jl/actions/runs/32933032031) fails at the end of `makedocs`, after every `@example` block has already run:

```
ERROR: LoadError: `makedocs` encountered errors [:cross_references, :linkcheck] -- terminating build before rendering.
```

`docs/make.jl` no longer passes `warnonly = [:missing_docs, :cross_references]`, so both of these are now hard errors rather than warnings. Two pre-existing problems in `docs/src` were surfaced by that:

1. **`:cross_references`** — `Cannot resolve @ref for md"[NLopt.jl](@ref)" in docs/src/optimization_packages/multistartoptimization.md`. `optimization_packages/nlopt.md` titles its header `# [NLopt.jl](@id nlopt)`, so the anchor is registered under the id `nlopt`, not under the header text, and a bare `@ref` can no longer find it.

2. **`:linkcheck`** — `linkcheck 'https://manoptjl.org/stable/solvers/adaptive-regularization-with-cubics/' status: 404`. Manopt serves that solver page at `.../solvers/adaptive_regularization_with_cubics/` (underscores). This link came in with #1315, which restored the `AdaptiveRegularizationCubicOptimizer` and `TrustRegionsOptimizer` rows to the methods list.

## Fix

- Link to `[NLopt.jl](@ref nlopt)`, matching how `API/reexports.md`, `optim.md`, `manopt.md` and the tutorials already reference these pages.
- Correct the Manopt URL to the underscored path.

## Verification

A full `docs/make.jl` build is ~1h of solver examples, so I verified the two failing passes directly with Documenter 1 on a minimal site built from the real `multistartoptimization.md` plus a stub page carrying the `@id nlopt` anchor and the two Manopt links:

- Reverting to `[NLopt.jl](@ref)` reproduces the exact CI error (`Cannot resolve @ref for md"[NLopt.jl](@ref)"`); with `@ref nlopt` the `CrossReferences` pass is clean.
- `CheckDocument` runs `linkcheck` over the corrected Manopt URLs with no error or warning, and the document renders.

`curl -o /dev/null -w '%{http_code}'` confirms 404 for the hyphenated URL and 200 for the underscored one.

No other cross-reference or linkcheck errors were reported in the failing run, so these two are the complete set. Nothing outside `docs/src` is touched and no version is bumped.

Made with [Cursor](https://cursor.com)