### PR TITLE
qa: enforce strict imports and recursive ambiguity checks

### DIFF
--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -3,22 +3,34 @@ $(DocStringExtensions.README)
 """
 module Optimization
 
-using DocStringExtensions
-using Reexport
-# `OptimizationBase` curates its own public surface, so re-exporting it wholesale is a
-# bounded, reviewable act. `SciMLBase`/`ADTypes` are deliberately *not* re-exported:
-# blanket-reexporting them is what put 263 names — most of SciMLOperators among them —
-# into every `using Optimization` namespace.
-@reexport using OptimizationBase
-using SciMLBase, ADTypes
+import DocStringExtensions: DocStringExtensions
+import Reexport: Reexport, @reexport
+@reexport import OptimizationBase: OptimizationBase, AutoEnzyme, AutoFiniteDiff,
+    AutoForwardDiff,
+    AutoMooncake, AutoReverseDiff, AutoSparse, AutoSymbolics, AutoTracker, AutoZygote,
+    DEFAULT_CALLBACK, DEFAULT_DATA, EnsembleDistributed, EnsembleProblem, EnsembleSerial,
+    EnsembleThreads, IncompatibleOptimizerError, MaxSense, MinSense,
+    MultiObjectiveOptimizationFunction, NoAD, ObjSense, OptimizationCache,
+    OptimizationFunction, OptimizationProblem, OptimizationSolution, OptimizationStats,
+    OptimizationVerbosity, OptimizerMissingError, ReturnCode, allowsbounds, allowscallback,
+    allowsconstraints, init, lag_hess_structure, remake, requiresbounds, requiresconshess,
+    requiresconsjac, requiresconstraints, requiresgradient, requireshessian, solve, solve!,
+    successful_retcode
+import SciMLBase: SciMLBase
+import ADTypes: ADTypes
 
-using Logging, ConsoleProgressMonitor, TerminalLoggers, LoggingExtras
-using ArrayInterface, Base.Iterators, SparseArrays, LinearAlgebra
+import Logging: Logging
+import ConsoleProgressMonitor: ConsoleProgressMonitor
+import TerminalLoggers: TerminalLoggers
+import LoggingExtras: LoggingExtras
+import ArrayInterface: ArrayInterface
+import Base.Iterators: Iterators
+import SparseArrays: SparseArrays
+import LinearAlgebra: LinearAlgebra
 
 import OptimizationBase: instantiate_function, OptimizationCache, ReInitCache
 import SciMLBase: OptimizationProblem, OptimizationFunction, OptimizationStats
 
-export ObjSense, MaxSense, MinSense
-export solve
+export OptimizationBase
 
 end # module

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,9 +3,6 @@ using Test
 
 include("rendered_docs.jl")
 
-# no_implicit_imports: Optimization is a facade that `@reexport`s SciMLBase/ADTypes/
-# OptimizationBase and `using`s many helper modules; the implicit-import surface is
-# large and intentional. Tracked as known-broken (SciML/Optimization.jl).
 # no_stale_explicit_imports ignores: `instantiate_function` is reached as
 # `Optimization.instantiate_function` by downstream/tests; `ReInitCache` and
 # `OptimizationStats` are part of the intentionally re-surfaced cache/stats API.
@@ -15,7 +12,6 @@ run_qa(
     Optimization;
     explicit_imports = true,
     aqua_kwargs = (;
-        ambiguities = (; recursive = false),
         piracies = (;
             treat_as_own = [
                 SciMLBase.OptimizationProblem,
@@ -38,7 +34,6 @@ run_qa(
             ),
         ),
     ),
-    ei_broken = (:no_implicit_imports,),
     # `Optimization` is the umbrella over `OptimizationBase`, which curates its own
     # public API; re-exporting exactly that set is the facade's whole purpose.
     reexports_allow = optimization_reexports_allow(Optimization.OptimizationBase),


### PR DESCRIPTION
## What changed

Replaces the umbrella package's implicit and whole-module `OptimizationBase` imports with explicit named re-exports, retaining the existing public names. Enables recursive Aqua ambiguity detection and the ExplicitImports implicit-import check without adding ignores.

Ignore until reviewed by @ChrisRackauckas.

## Verification

- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`\n  - `QA | 21/21 passed`\n- `GROUP=Core julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`\n  - exited `0`\n- Runic source-format equality check, `typos src/Optimization.jl test/qa/qa.jl`, and `git diff --check` passed.\n\n## Not Verified\n\n- AD, GPU, downstream, and every sublibrary group were not run locally; this change is confined to the root module and root QA configuration.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nhttps://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791