### PR TITLE
qa: use shared reexport documentation policy

### DIFF
--- a/lib/OptimizationNLopt/test/qa/qa.jl
+++ b/lib/OptimizationNLopt/test/qa/qa.jl
@@ -49,8 +49,6 @@ run_qa(
         all_explicit_imports_are_public = (; ignore = (:deduce_retcode,)),
     ),
     ei_broken = (:no_implicit_imports,),
-    # NLopt.jl ships no docstring for `Opt` or `Algorithm`; the obligation is NLopt's.
-    api_docs_kwargs = (; ignore = (:Algorithm, :Opt)),
     reexports_allow = NLOPT_REEXPORTS,
 )
 

--- a/lib/OptimizationOptimJL/test/qa/qa.jl
+++ b/lib/OptimizationOptimJL/test/qa/qa.jl
@@ -51,8 +51,6 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:AbstractConstrainedOptimizer, :AbstractOptimizer, :ConstrainedOptimizer, :KrylovTrustRegion, :NLSolversBase, :NoAD, :OptimizationState, :OptimizationStats, :Options, :ZerothOrderOptimizer, :__init, :__solve, :_check_and_convert_maxiters, :_check_and_convert_maxtime, :alloc_DF, :alloc_H, :allowscallback, :allowsfg, :converged, :iteration_limit_reached, :requiresbounds, :requiresconshess, :requiresconsjac, :requiresgradient, :requireshessian, :supports_sense, :value)),
     ),
     ei_broken = (:no_implicit_imports,),
-    # Optim.jl ships no docstring for these two optimizers; the obligation is Optim's.
-    api_docs_kwargs = (; ignore = (:AcceleratedGradientDescent, :MomentumGradientDescent)),
     reexports_allow = OPTIMJL_REEXPORTS,
 )
 

--- a/lib/OptimizationOptimisers/test/qa/qa.jl
+++ b/lib/OptimizationOptimisers/test/qa/qa.jl
@@ -45,12 +45,6 @@ run_qa(
         all_qualified_accesses_are_public = (; ignore = (:OptimizationState, :OptimizationStats, :__init, :__solve, :_check_and_convert_maxiters, :allowscallback, :allowsfg, :isa_dataiterator, :requiresgradient)),
     ),
     ei_broken = (:no_implicit_imports,),
-    # Optimisers.jl gives its legacy all-caps aliases no docstring of their own; they
-    # are kept public here so code written against `ADAM(0.01)` keeps working. The
-    # docstring obligation is Optimisers.jl's.
-    api_docs_kwargs = (;
-        ignore = (:ADADelta, :ADAGrad, :ADAM, :ADAMW, :NADAM, :OADAM, :RADAM),
-    ),
     reexports_allow = OPTIMISERS_REEXPORTS,
 )
 


### PR DESCRIPTION
Removes the three repository-specific public-doc exceptions for documented, explicitly allow-listed external reexports in the Optimisers, NLopt, and Optim.jl wrappers. This depends on https://github.com/SciML/SciMLTesting.jl/pull/62.

Ignore until reviewed by @ChrisRackauckas.

## Verification

- `git diff --check`
- `typos` over all three changed QA files
- Each existing QA file was run in an isolated environment with the SciMLTesting source from PR 62:
  - OptimizationOptimisers: `Quality Assurance | 20 pass, 1 broken`; reexports `60 / 60`
  - OptimizationNLopt: `Quality Assurance | 20 pass, 1 broken`; reexports `6 / 6`
  - OptimizationOptimJL: `Quality Assurance | 20 pass, 1 broken`; reexports `34 / 34`

The one broken check in each suite predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/019f4028-d2ae-7a12-aff0-7d996bd9c791