### PR TITLE
Develop Optimization lib/* in Downstream CI

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -21,5 +21,6 @@ jobs:
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
       group: "${{ matrix.package.group }}"
+      upstream-subdirs: ".,lib/*"
       julia-version: "1"
     secrets: "inherit"


### PR DESCRIPTION
Workflow-only. Optimization is a 27-package monorepo. Downstream IntegrationTest (DiffEqFlux `All`, NeuralPDE `NNPDE1`/`NNPDE2`, ModelingToolkit `Optimization`) only `Pkg.develop`'d the repo root, so solver backends (`OptimizationOptimisers`, `OptimizationOptimJL`, …) came from the registry instead of the PR.

## What changed

Pass `upstream-subdirs: ".,lib/*"` to `SciML/.github/.github/workflows/downstream.yml@v1`, same pattern as OrdinaryDiffEq.

Matrix `group` values are unchanged and already match downstream GROUPs.

## Verification

Post-change YAML: `upstream-subdirs` is `.,lib/*`. Groups still `All` / `NNPDE1` / `NNPDE2` / `Optimization`.

Did not wait for GitHub Actions. Downstream GPU / allowed-to-fail jobs not re-run here.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)