### PR TITLE
Release OptimizationBase 5.5.1

### DIFF
--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.5.0"
+version = "5.5.1"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Releases the unreleased `lib/OptimizationBase` changes since 5.5.0:

- #1319 — `Preserve AbstractVector containers in AutoEnzyme Hessians`. Reworks `ext/OptimizationEnzymeExt.jl` so Hessian and `fgh!` construction preserve the input `AbstractVector` container and build the second-order seed/shadow caches once during `instantiate_function`.
- #1320 — compat: drop stale majors.

**Patch**: the change is confined to an extension's internals; no exported or `public` name is added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R