### PR TITLE
Cap Enzyme Lagrangian Hessian batches at eight on every Julia version

### DIFF
--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -80,11 +80,9 @@ function lagrangian(x, _f::Function, cons::Function, p, λ, σ = one(eltype(x)))
     return σ * _f(x, p) + dot(λ, res)
 end
 
-function lag_grad(mode, x, dx, lagrangian::Function, _f::Function, cons::Function, p, σ, λ)
-    Enzyme.autodiff_deferred(
-        mode, Const(lagrangian), Active, Enzyme.Duplicated(x, dx),
-        Const(_f), Const(cons), Const(p), Const(λ), Const(σ)
-    )
+function lag_grad(mode, x, dx, f)
+    Enzyme.make_zero!(dx)
+    Enzyme.autodiff(mode, Const(f), Active, Enzyme.Duplicated(x, dx))
     return nothing
 end
 
@@ -499,6 +497,7 @@ function OptimizationBase.instantiate_function(
         end
 
         function fill_lag_hessian!(θ, σ, μ, p)
+            lag = x -> lagrangian(x, f.f, f.cons, p, μ, σ)
             for i in eachindex(θ)
                 Enzyme.make_zero!(lag_bθ)
                 Enzyme.make_zero!(lag_vdbθ[i])
@@ -507,13 +506,8 @@ function OptimizationBase.instantiate_function(
                     lag_grad,
                     Const(rmode),
                     Enzyme.Duplicated(θ, lag_vdθ[i]),
-                    Enzyme.DuplicatedNoNeed(lag_bθ, lag_vdbθ[i]),
-                    Const(lagrangian),
-                    Const(f.f),
-                    Const(f.cons),
-                    Const(p),
-                    Const(σ),
-                    Const(μ)
+                    Enzyme.Duplicated(lag_bθ, lag_vdbθ[i]),
+                    Const(lag)
                 )
             end
             return nothing
@@ -536,7 +530,9 @@ function OptimizationBase.instantiate_function(
             fill_lag_hessian!(θ, σ, μ, p)
 
             for i in eachindex(θ)
-                H[i, :] .= lag_vdbθ[i]
+                vec_lagv = lag_vdbθ[i]
+                H[i, 1:i] .= @view(vec_lagv[1:i])
+                H[1:i, i] .= @view(vec_lagv[1:i])
             end
             return
         end

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -498,23 +498,29 @@ function OptimizationBase.instantiate_function(
             lag_vdbθ = Tuple((copy(r) for r in eachrow(f.hess_prototype)))
         end
 
-        function lag_h!(h, θ, σ, μ, p = p)
-            Enzyme.make_zero!(lag_bθ)
-            Enzyme.make_zero!.(lag_vdbθ)
+        function fill_lag_hessian!(θ, σ, μ, p)
+            for i in eachindex(θ)
+                Enzyme.make_zero!(lag_bθ)
+                Enzyme.make_zero!(lag_vdbθ[i])
+                Enzyme.autodiff(
+                    fmode,
+                    lag_grad,
+                    Const(rmode),
+                    Enzyme.Duplicated(θ, lag_vdθ[i]),
+                    Enzyme.DuplicatedNoNeed(lag_bθ, lag_vdbθ[i]),
+                    Const(lagrangian),
+                    Const(f.f),
+                    Const(f.cons),
+                    Const(p),
+                    Const(σ),
+                    Const(μ)
+                )
+            end
+            return nothing
+        end
 
-            Enzyme.autodiff(
-                fmode,
-                lag_grad,
-                Const(rmode),
-                Enzyme.BatchDuplicated(θ, lag_vdθ),
-                Enzyme.BatchDuplicatedNoNeed(lag_bθ, lag_vdbθ),
-                Const(lagrangian),
-                Const(f.f),
-                Const(f.cons),
-                Const(p),
-                Const(σ),
-                Const(μ)
-            )
+        function lag_h!(h, θ, σ, μ, p = p)
+            fill_lag_hessian!(θ, σ, μ, p)
             k = 0
 
             for i in eachindex(θ)
@@ -527,22 +533,7 @@ function OptimizationBase.instantiate_function(
 
         function lag_h!(H::AbstractMatrix, θ, σ, μ, p = p)
             Enzyme.make_zero!(H)
-            Enzyme.make_zero!(lag_bθ)
-            Enzyme.make_zero!.(lag_vdbθ)
-
-            Enzyme.autodiff(
-                fmode,
-                lag_grad,
-                Const(rmode),
-                Enzyme.BatchDuplicated(θ, lag_vdθ),
-                Enzyme.BatchDuplicatedNoNeed(lag_bθ, lag_vdbθ),
-                Const(lagrangian),
-                Const(f.f),
-                Const(f.cons),
-                Const(p),
-                Const(σ),
-                Const(μ)
-            )
+            fill_lag_hessian!(θ, σ, μ, p)
 
             for i in eachindex(θ)
                 H[i, :] .= lag_vdbθ[i]

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -98,6 +98,11 @@ const _HESSIAN_BATCH_CAP = 8
 
 _hessian_batch_width(n) = min(max(n, 1), _HESSIAN_BATCH_CAP)
 
+# Enzyme forward-over-reverse BatchDuplicated through the Lagrangian currently
+# yields NaN Hessian rows on Julia 1.12+. Keep the width-8 Hessian-style batches
+# elsewhere; fall back to one seed at a time there.
+_lag_hessian_batch_width(n) = VERSION >= v"1.12" ? 1 : _hessian_batch_width(n)
+
 function _onehot_cache(x, batch_width)
     n = length(x)
     cache_length = cld(n, batch_width) * batch_width
@@ -486,29 +491,59 @@ function OptimizationBase.instantiate_function(
     end
 
     if lag_h == true && f.lag_h === nothing && cons !== nothing
-        lag_vdθ = Tuple((Array(r) for r in eachrow(I(length(x)) * one(eltype(x)))))
+        # Cap Enzyme FoR batches like objective Hessians. Full-width batches have
+        # superlinear compile cost; row-wise (width 1) is only used where Enzyme
+        # BatchDuplicated through the Lagrangian is unreliable (see
+        # `_lag_hessian_batch_width`).
+        lag_batch_width = _lag_hessian_batch_width(length(x))
+        lag_vdθ = _onehot_cache(x, lag_batch_width)
         lag_bθ = zeros(eltype(x), length(x))
+        lag_batch_width_value = Val(lag_batch_width)
 
         if f.hess_prototype === nothing
-            lag_vdbθ = Tuple(zeros(eltype(x), length(x)) for i in eachindex(x))
+            lag_vdbθ = ntuple(_ -> zeros(eltype(x), length(x)), length(lag_vdθ))
         else
             #useless right now, looks like there is no way to tell Enzyme the sparsity pattern?
-            lag_vdbθ = Tuple((copy(r) for r in eachrow(f.hess_prototype)))
+            prototype_rows = eachrow(f.hess_prototype)
+            lag_vdbθ = ntuple(length(lag_vdθ)) do i
+                i <= length(x) ? copy(prototype_rows[i]) : zeros(eltype(x), length(x))
+            end
         end
 
         function fill_lag_hessian!(θ, σ, μ, p)
             lag = x -> lagrangian(x, f.f, f.cons, p, μ, σ)
-            for i in eachindex(θ)
-                Enzyme.make_zero!(lag_bθ)
-                Enzyme.make_zero!(lag_vdbθ[i])
-                Enzyme.autodiff(
-                    fmode,
-                    lag_grad,
-                    Const(rmode),
-                    Enzyme.Duplicated(θ, lag_vdθ[i]),
-                    Enzyme.Duplicated(lag_bθ, lag_vdbθ[i]),
-                    Const(lag)
-                )
+            if lag_batch_width == 1
+                for i in eachindex(θ)
+                    Enzyme.make_zero!(lag_bθ)
+                    Enzyme.make_zero!(lag_vdbθ[i])
+                    Enzyme.autodiff(
+                        fmode,
+                        lag_grad,
+                        Const(rmode),
+                        Enzyme.Duplicated(θ, lag_vdθ[i]),
+                        Enzyme.Duplicated(lag_bθ, lag_vdbθ[i]),
+                        Const(lag)
+                    )
+                end
+            else
+                for first_index in _batch_starts(lag_vdθ, lag_batch_width_value)
+                    vdθ_batch = _cache_batch(
+                        lag_vdθ, first_index, lag_batch_width_value
+                    )
+                    vdbθ_batch = _cache_batch(
+                        lag_vdbθ, first_index, lag_batch_width_value
+                    )
+                    Enzyme.make_zero!(lag_bθ)
+                    Enzyme.make_zero!.(vdbθ_batch)
+                    Enzyme.autodiff(
+                        fmode,
+                        lag_grad,
+                        Const(rmode),
+                        Enzyme.BatchDuplicated(θ, vdθ_batch),
+                        Enzyme.BatchDuplicated(lag_bθ, vdbθ_batch),
+                        Const(lag)
+                    )
+                end
             end
             return nothing
         end
@@ -847,37 +882,61 @@ function OptimizationBase.instantiate_function(
     end
 
     if lag_h == true && f.lag_h === nothing && cons !== nothing
-        lag_vdθ = Tuple((Array(r) for r in eachrow(I(length(x)) * one(eltype(x)))))
+        lag_batch_width = _lag_hessian_batch_width(length(x))
+        lag_vdθ = _onehot_cache(x, lag_batch_width)
         lag_bθ = zeros(eltype(x), length(x))
+        lag_batch_width_value = Val(lag_batch_width)
         if f.hess_prototype === nothing
-            lag_vdbθ = Tuple(zeros(eltype(x), length(x)) for i in eachindex(x))
+            lag_vdbθ = ntuple(_ -> zeros(eltype(x), length(x)), length(lag_vdθ))
         else
-            lag_vdbθ = Tuple((copy(r) for r in eachrow(f.hess_prototype)))
+            prototype_rows = eachrow(f.hess_prototype)
+            lag_vdbθ = ntuple(length(lag_vdθ)) do i
+                i <= length(x) ? copy(prototype_rows[i]) : zeros(eltype(x), length(x))
+            end
         end
 
         function lag_h!(θ, σ, μ, p = p)
-            Enzyme.make_zero!(lag_bθ)
-            Enzyme.make_zero!.(lag_vdbθ)
+            lag = x -> lagrangian(x, f.f, f.cons, p, μ, σ)
+            if lag_batch_width == 1
+                for i in eachindex(θ)
+                    Enzyme.make_zero!(lag_bθ)
+                    Enzyme.make_zero!(lag_vdbθ[i])
+                    Enzyme.autodiff(
+                        fmode,
+                        lag_grad,
+                        Const(rmode),
+                        Enzyme.Duplicated(θ, lag_vdθ[i]),
+                        Enzyme.Duplicated(lag_bθ, lag_vdbθ[i]),
+                        Const(lag)
+                    )
+                end
+            else
+                for first_index in _batch_starts(lag_vdθ, lag_batch_width_value)
+                    vdθ_batch = _cache_batch(
+                        lag_vdθ, first_index, lag_batch_width_value
+                    )
+                    vdbθ_batch = _cache_batch(
+                        lag_vdbθ, first_index, lag_batch_width_value
+                    )
+                    Enzyme.make_zero!(lag_bθ)
+                    Enzyme.make_zero!.(vdbθ_batch)
+                    Enzyme.autodiff(
+                        fmode,
+                        lag_grad,
+                        Const(rmode),
+                        Enzyme.BatchDuplicated(θ, vdθ_batch),
+                        Enzyme.BatchDuplicated(lag_bθ, vdbθ_batch),
+                        Const(lag)
+                    )
+                end
+            end
 
-            Enzyme.autodiff(
-                fmode,
-                lag_grad,
-                Const(rmode),
-                Enzyme.BatchDuplicated(θ, lag_vdθ),
-                Enzyme.BatchDuplicatedNoNeed(lag_bθ, lag_vdbθ),
-                Const(lagrangian),
-                Const(f.f),
-                Const(f.cons),
-                Const(p),
-                Const(σ),
-                Const(μ)
-            )
-
+            n = length(θ)
+            res = zeros(eltype(θ), n * (n + 1) ÷ 2)
             k = 0
-
             for i in eachindex(θ)
                 vec_lagv = lag_vdbθ[i]
-                res[(k + 1):(k + i), :] .= @view(vec_lagv[1:i])
+                res[(k + 1):(k + i)] .= @view(vec_lagv[1:i])
                 k += i
             end
             return res

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -80,6 +80,10 @@ function lagrangian(x, _f::Function, cons::Function, p, λ, σ = one(eltype(x)))
     return σ * _f(x, p) + dot(λ, res)
 end
 
+function lagrangian_oop(x, _f::Function, cons::Function, p, λ, σ = one(eltype(x)))
+    return σ * _f(x, p) + dot(λ, cons(x, p))
+end
+
 function lag_grad(mode, x, dx, f)
     Enzyme.make_zero!(dx)
     Enzyme.autodiff(mode, Const(f), Active, Enzyme.Duplicated(x, dx))
@@ -98,10 +102,12 @@ const _HESSIAN_BATCH_CAP = 8
 
 _hessian_batch_width(n) = min(max(n, 1), _HESSIAN_BATCH_CAP)
 
-# Enzyme forward-over-reverse BatchDuplicated through the Lagrangian currently
-# yields NaN Hessian rows on Julia 1.12+. Keep the width-8 Hessian-style batches
-# elsewhere; fall back to one seed at a time there.
-_lag_hessian_batch_width(n) = VERSION >= v"1.12" ? 1 : _hessian_batch_width(n)
+# Enzyme forward-over-reverse BatchDuplicated through the Lagrangian yields NaN
+# Hessian rows on Julia 1.12.7. Keep the width-8 Hessian-style batches elsewhere;
+# fall back to one seed at a time only on the known-broken 1.12 series.
+# TODO: re-enable width-8 BatchDuplicated once verified on Julia 1.13+.
+_lag_hessian_batch_width(n) =
+    (v"1.12" <= VERSION < v"1.13") ? 1 : _hessian_batch_width(n)
 
 function _onehot_cache(x, batch_width)
     n = length(x)
@@ -492,9 +498,8 @@ function OptimizationBase.instantiate_function(
 
     if lag_h == true && f.lag_h === nothing && cons !== nothing
         # Cap Enzyme FoR batches like objective Hessians. Full-width batches have
-        # superlinear compile cost; row-wise (width 1) is only used where Enzyme
-        # BatchDuplicated through the Lagrangian is unreliable (see
-        # `_lag_hessian_batch_width`).
+        # superlinear compile cost; row-wise (width 1) is only used on the known-broken
+        # Julia 1.12 series (see `_lag_hessian_batch_width`).
         lag_batch_width = _lag_hessian_batch_width(length(x))
         lag_vdθ = _onehot_cache(x, lag_batch_width)
         lag_bθ = zeros(eltype(x), length(x))
@@ -896,7 +901,7 @@ function OptimizationBase.instantiate_function(
         end
 
         function lag_h!(θ, σ, μ, p = p)
-            lag = x -> lagrangian(x, f.f, f.cons, p, μ, σ)
+            lag = x -> lagrangian_oop(x, f.f, f.cons, p, μ, σ)
             if lag_batch_width == 1
                 for i in eachindex(θ)
                     Enzyme.make_zero!(lag_bθ)
@@ -931,15 +936,14 @@ function OptimizationBase.instantiate_function(
                 end
             end
 
-            n = length(θ)
-            res = zeros(eltype(θ), n * (n + 1) ÷ 2)
-            k = 0
+            H = Matrix{eltype(θ)}(undef, length(θ), length(θ))
+            fill!(H, zero(eltype(θ)))
             for i in eachindex(θ)
                 vec_lagv = lag_vdbθ[i]
-                res[(k + 1):(k + i)] .= @view(vec_lagv[1:i])
-                k += i
+                H[i, 1:i] .= @view(vec_lagv[1:i])
+                H[1:i, i] .= @view(vec_lagv[1:i])
             end
-            return res
+            return H
         end
     elseif lag_h == true && cons !== nothing
         lag_h! = (θ, σ, μ, p = p) -> f.lag_h(θ, σ, μ, p)

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -3,7 +3,7 @@ module OptimizationEnzymeExt
 import OptimizationBase, OptimizationBase.ArrayInterface
 import SciMLBase: OptimizationFunction
 import SciMLBase
-import OptimizationBase.LinearAlgebra: I, dot
+import OptimizationBase.LinearAlgebra: I
 import OptimizationBase.ADTypes: AutoEnzyme
 using Enzyme
 using Core: Vararg
@@ -77,11 +77,20 @@ end
 function lagrangian(x, _f::Function, cons::Function, p, λ, σ = one(eltype(x)))
     res = zeros(eltype(x), length(λ))
     cons(res, x, p)
-    return σ * _f(x, p) + dot(λ, res)
+    return σ * _f(x, p) + lagrangian_constraints(λ, res)
 end
 
 function lagrangian_oop(x, _f::Function, cons::Function, p, λ, σ = one(eltype(x)))
-    return σ * _f(x, p) + dot(λ, cons(x, p))
+    return σ * _f(x, p) + lagrangian_constraints(λ, cons(x, p))
+end
+
+# Keep the constraint contraction in Julia for nested Enzyme differentiation.
+function lagrangian_constraints(λ, res)
+    value = zero(promote_type(eltype(λ), eltype(res)))
+    for i in eachindex(λ, res)
+        value += conj(λ[i]) * res[i]
+    end
+    return value
 end
 
 function lag_grad(mode, x, dx, f)
@@ -102,12 +111,23 @@ const _HESSIAN_BATCH_CAP = 8
 
 _hessian_batch_width(n) = min(max(n, 1), _HESSIAN_BATCH_CAP)
 
-# Enzyme forward-over-reverse BatchDuplicated through the Lagrangian yields NaN
-# Hessian rows on Julia 1.12.7. Keep the width-8 Hessian-style batches elsewhere;
-# fall back to one seed at a time only on the known-broken 1.12 series.
-# TODO: re-enable width-8 BatchDuplicated once verified on Julia 1.13+.
-_lag_hessian_batch_width(n) =
-    (v"1.12" <= VERSION < v"1.13") ? 1 : _hessian_batch_width(n)
+function lag_hessian!(θ, lag, fmode, rmode, vdθ, bθ, vdbθ, batch_width)
+    for first_index in _batch_starts(vdθ, batch_width)
+        vdθ_batch = _cache_batch(vdθ, first_index, batch_width)
+        vdbθ_batch = _cache_batch(vdbθ, first_index, batch_width)
+        Enzyme.make_zero!(bθ)
+        Enzyme.make_zero!.(vdbθ_batch)
+        Enzyme.autodiff(
+            fmode,
+            lag_grad,
+            Const(rmode),
+            Enzyme.BatchDuplicated(θ, vdθ_batch),
+            Enzyme.BatchDuplicated(bθ, vdbθ_batch),
+            Const(lag)
+        )
+    end
+    return nothing
+end
 
 function _onehot_cache(x, batch_width)
     n = length(x)
@@ -497,10 +517,7 @@ function OptimizationBase.instantiate_function(
     end
 
     if lag_h == true && f.lag_h === nothing && cons !== nothing
-        # Cap Enzyme FoR batches like objective Hessians. Full-width batches have
-        # superlinear compile cost; row-wise (width 1) is only used on the known-broken
-        # Julia 1.12 series (see `_lag_hessian_batch_width`).
-        lag_batch_width = _lag_hessian_batch_width(length(x))
+        lag_batch_width = _hessian_batch_width(length(x))
         lag_vdθ = _onehot_cache(x, lag_batch_width)
         lag_bθ = zeros(eltype(x), length(x))
         lag_batch_width_value = Val(lag_batch_width)
@@ -517,39 +534,9 @@ function OptimizationBase.instantiate_function(
 
         function fill_lag_hessian!(θ, σ, μ, p)
             lag = x -> lagrangian(x, f.f, f.cons, p, μ, σ)
-            if lag_batch_width == 1
-                for i in eachindex(θ)
-                    Enzyme.make_zero!(lag_bθ)
-                    Enzyme.make_zero!(lag_vdbθ[i])
-                    Enzyme.autodiff(
-                        fmode,
-                        lag_grad,
-                        Const(rmode),
-                        Enzyme.Duplicated(θ, lag_vdθ[i]),
-                        Enzyme.Duplicated(lag_bθ, lag_vdbθ[i]),
-                        Const(lag)
-                    )
-                end
-            else
-                for first_index in _batch_starts(lag_vdθ, lag_batch_width_value)
-                    vdθ_batch = _cache_batch(
-                        lag_vdθ, first_index, lag_batch_width_value
-                    )
-                    vdbθ_batch = _cache_batch(
-                        lag_vdbθ, first_index, lag_batch_width_value
-                    )
-                    Enzyme.make_zero!(lag_bθ)
-                    Enzyme.make_zero!.(vdbθ_batch)
-                    Enzyme.autodiff(
-                        fmode,
-                        lag_grad,
-                        Const(rmode),
-                        Enzyme.BatchDuplicated(θ, vdθ_batch),
-                        Enzyme.BatchDuplicated(lag_bθ, vdbθ_batch),
-                        Const(lag)
-                    )
-                end
-            end
+            lag_hessian!(
+                θ, lag, fmode, rmode, lag_vdθ, lag_bθ, lag_vdbθ, lag_batch_width_value
+            )
             return nothing
         end
 
@@ -887,7 +874,7 @@ function OptimizationBase.instantiate_function(
     end
 
     if lag_h == true && f.lag_h === nothing && cons !== nothing
-        lag_batch_width = _lag_hessian_batch_width(length(x))
+        lag_batch_width = _hessian_batch_width(length(x))
         lag_vdθ = _onehot_cache(x, lag_batch_width)
         lag_bθ = zeros(eltype(x), length(x))
         lag_batch_width_value = Val(lag_batch_width)
@@ -902,39 +889,9 @@ function OptimizationBase.instantiate_function(
 
         function lag_h!(θ, σ, μ, p = p)
             lag = x -> lagrangian_oop(x, f.f, f.cons, p, μ, σ)
-            if lag_batch_width == 1
-                for i in eachindex(θ)
-                    Enzyme.make_zero!(lag_bθ)
-                    Enzyme.make_zero!(lag_vdbθ[i])
-                    Enzyme.autodiff(
-                        fmode,
-                        lag_grad,
-                        Const(rmode),
-                        Enzyme.Duplicated(θ, lag_vdθ[i]),
-                        Enzyme.Duplicated(lag_bθ, lag_vdbθ[i]),
-                        Const(lag)
-                    )
-                end
-            else
-                for first_index in _batch_starts(lag_vdθ, lag_batch_width_value)
-                    vdθ_batch = _cache_batch(
-                        lag_vdθ, first_index, lag_batch_width_value
-                    )
-                    vdbθ_batch = _cache_batch(
-                        lag_vdbθ, first_index, lag_batch_width_value
-                    )
-                    Enzyme.make_zero!(lag_bθ)
-                    Enzyme.make_zero!.(vdbθ_batch)
-                    Enzyme.autodiff(
-                        fmode,
-                        lag_grad,
-                        Const(rmode),
-                        Enzyme.BatchDuplicated(θ, vdθ_batch),
-                        Enzyme.BatchDuplicated(lag_bθ, vdbθ_batch),
-                        Const(lag)
-                    )
-                end
-            end
+            lag_hessian!(
+                θ, lag, fmode, rmode, lag_vdθ, lag_bθ, lag_vdbθ, lag_batch_width_value
+            )
 
             H = Matrix{eltype(θ)}(undef, length(θ), length(θ))
             fill!(H, zero(eltype(θ)))

--- a/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
+++ b/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
@@ -46,5 +46,7 @@ function check_lagrangian_hessian(N)
 end
 
 @testset "Enzyme Lagrangian Hessian" begin
-    foreach(check_lagrangian_hessian, (1:10..., 20, 40, 60))
+    @testset "N = $N" for N in (1:10..., 20, 40, 60)
+        check_lagrangian_hessian(N)
+    end
 end

--- a/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
+++ b/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
@@ -1,0 +1,50 @@
+using ChainRulesCore, Enzyme, OptimizationBase, Test
+
+function check_lagrangian_hessian(N)
+    h = 1 / N
+    alpha = 350
+    x_offset = N + 1
+    u_offset = 2(N + 1)
+    function objective(x, p)
+        return sum(
+            0.5 * h * (x[u_offset + i + 1]^2 + x[u_offset + i]^2) +
+                0.5 * alpha * h * (cos(x[i + 1]) + cos(x[i])) for i in 1:N
+        ) + x[1] * x[2]
+    end
+    function constraint!(res, x, p)
+        for i in 1:N
+            res[i] = x[x_offset + i + 1] - x[x_offset + i] -
+                0.5 * h * (sin(x[i + 1]) + sin(x[i]))
+            res[N + i] = x[i + 1] - x[i] -
+                0.5 * h * (x[u_offset + i + 1] + x[u_offset + i])
+        end
+        return nothing
+    end
+
+    x = zeros(3(N + 1))
+    f = OptimizationFunction(objective, AutoEnzyme(); cons = constraint!)
+    instantiated = OptimizationBase.instantiate_function(
+        f, x, AutoEnzyme(), nothing, 2N; lag_h = true
+    )
+    multipliers = ones(2N)
+    expected = zeros(length(x), length(x))
+    for i in 1:(N + 1)
+        expected[i, i] = (i == 1 || i == N + 1) ? -0.5alpha * h : -alpha * h
+        expected[u_offset + i, u_offset + i] =
+            (i == 1 || i == N + 1) ? h : 2h
+    end
+    expected[1, 2] = expected[2, 1] = 1
+
+    packed = zeros(length(x) * (length(x) + 1) ÷ 2)
+    instantiated.lag_h(packed, x, 1.0, multipliers)
+    @test packed ≈ [expected[i, j] for i in axes(expected, 1) for j in 1:i]
+
+    dense = zeros(length(x), length(x))
+    instantiated.lag_h(dense, x, 1.0, multipliers)
+    @test dense ≈ expected
+    return nothing
+end
+
+@testset "Enzyme Lagrangian Hessian" begin
+    foreach(check_lagrangian_hessian, (1:10..., 20, 40, 60))
+end

--- a/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
+++ b/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
@@ -1,6 +1,20 @@
-using ChainRulesCore, Enzyme, OptimizationBase, Test
+using ChainRulesCore, Enzyme, ForwardDiff, LinearAlgebra, OptimizationBase, Test
 
-function check_lagrangian_hessian(N)
+function ref_lag_hess!(obj, cons!, x, σ, μ, p)
+    function lag(θ)
+        res = zeros(eltype(θ), length(μ))
+        cons!(res, θ, p)
+        return σ * obj(θ, p) + dot(μ, res)
+    end
+    return ForwardDiff.hessian(lag, x)
+end
+
+function ref_lag_hess(obj, cons, x, σ, μ, p)
+    lag(θ) = σ * obj(θ, p) + dot(μ, cons(θ, p))
+    return ForwardDiff.hessian(lag, x)
+end
+
+function check_inplace_clnlbeam(N; σ = 1.0)
     h = 1 / N
     alpha = 350
     x_offset = N + 1
@@ -21,32 +35,96 @@ function check_lagrangian_hessian(N)
         return nothing
     end
 
-    x = zeros(3(N + 1))
+    # Nonzero point so constraint Hessians (from sin) contribute.
+    x = collect(range(0.05; step = 0.01, length = 3(N + 1)))
+    multipliers = collect(range(0.25; step = 0.05, length = 2N))
     f = OptimizationFunction(objective, AutoEnzyme(); cons = constraint!)
     instantiated = OptimizationBase.instantiate_function(
         f, x, AutoEnzyme(), nothing, 2N; lag_h = true
     )
-    multipliers = ones(2N)
-    expected = zeros(length(x), length(x))
-    for i in 1:(N + 1)
-        expected[i, i] = (i == 1 || i == N + 1) ? -0.5alpha * h : -alpha * h
-        expected[u_offset + i, u_offset + i] =
-            (i == 1 || i == N + 1) ? h : 2h
-    end
-    expected[1, 2] = expected[2, 1] = 1
+    expected = ref_lag_hess!(objective, constraint!, x, σ, multipliers, nothing)
 
     packed = zeros(length(x) * (length(x) + 1) ÷ 2)
-    instantiated.lag_h(packed, x, 1.0, multipliers)
+    instantiated.lag_h(packed, x, σ, multipliers)
     @test packed ≈ [expected[i, j] for i in axes(expected, 1) for j in 1:i]
 
     dense = zeros(length(x), length(x))
-    instantiated.lag_h(dense, x, 1.0, multipliers)
+    instantiated.lag_h(dense, x, σ, multipliers)
     @test dense ≈ expected
     return nothing
 end
 
+function check_inplace_quadratic()
+    # Objective Hessian [[2,1],[1,4]]; constraint x₁²+x₂²-1 has Hessian 2I.
+    objective(x, p) = x[1]^2 + x[1] * x[2] + 2 * x[2]^2 + p[1] * x[1]
+    function constraint!(res, x, p)
+        res[1] = x[1]^2 + x[2]^2 - 1
+        return nothing
+    end
+
+    x = [0.3, -0.4]
+    p = [1.5]
+    f = OptimizationFunction(objective, AutoEnzyme(); cons = constraint!)
+    instantiated = OptimizationBase.instantiate_function(
+        f, x, AutoEnzyme(), p, 1; lag_h = true
+    )
+
+    @testset "σ = $σ, μ = $μ" for (σ, μ) in (
+            (1.0, [1.0]),
+            (0.0, [2.5]),
+            (2.0, [-1.5]),
+            (0.0, [0.0]),
+        )
+        expected = ref_lag_hess!(objective, constraint!, x, σ, μ, p)
+        dense = zeros(2, 2)
+        instantiated.lag_h(dense, x, σ, μ, p)
+        @test dense ≈ expected
+    end
+    return nothing
+end
+
+function check_oop_quadratic(n)
+    # Separable quartic objective + quadratic equality; n padded relative to
+    # the width-8 Enzyme batch size exercises full and partial batches.
+    objective(x, p) = sum(abs2(abs2(xi)) for xi in x) + p[1] * sum(x)
+    cons(x, p) = [sum(abs2, x) - 1, x[1] * x[min(2, n)] - p[2]]
+
+    x = collect(range(0.1; step = 0.05, length = n))
+    p = [0.3, -0.2]
+    μ = [1.25, -0.75]
+    f = OptimizationFunction{false}(objective, AutoEnzyme(); cons = cons)
+    instantiated = OptimizationBase.instantiate_function(
+        f, x, AutoEnzyme(), p, 2; lag_h = true
+    )
+
+    for σ in (1.0, 0.0, 2.5)
+        expected = ref_lag_hess(objective, cons, x, σ, μ, p)
+        H = instantiated.lag_h(x, σ, μ, p)
+        @test H isa Matrix
+        @test size(H) == (n, n)
+        @test H ≈ expected
+        @test H ≈ H'
+    end
+    return nothing
+end
+
 @testset "Enzyme Lagrangian Hessian" begin
-    @testset "N = $N" for N in (1:10..., 20, 40, 60)
-        check_lagrangian_hessian(N)
+    enzyme_ext = Base.get_extension(OptimizationBase, :OptimizationEnzymeExt)
+    @test enzyme_ext._lag_hessian_batch_width(4) ==
+        ((v"1.12" <= VERSION < v"1.13") ? 1 : 4)
+    @test enzyme_ext._lag_hessian_batch_width(17) ==
+        ((v"1.12" <= VERSION < v"1.13") ? 1 : 8)
+
+    @testset "in-place clnlbeam N = $N" for N in (1:10..., 20, 40, 60)
+        check_inplace_clnlbeam(N)
+        check_inplace_clnlbeam(N; σ = 0.0)
+    end
+
+    @testset "in-place quadratic σ/μ cases" begin
+        check_inplace_quadratic()
+    end
+
+    @testset "out-of-place quadratic n = $n" for n in (9, 17)
+        check_oop_quadratic(n)
     end
 end

--- a/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
+++ b/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
@@ -55,8 +55,7 @@ function check_inplace_clnlbeam(N; σ = 1.0)
 end
 
 function check_inplace_quadratic()
-    # Objective Hessian [[2,1],[1,4]]; constraint x₁²+x₂²-1 has Hessian 2I.
-    objective(x, p) = x[1]^2 + x[1] * x[2] + 2 * x[2]^2 + p[1] * x[1]
+    objective(x, p) = x[1]^2 + x[1] * x[2] + 2 * x[2]^2 + p[1] * x[1] * x[2]
     function constraint!(res, x, p)
         res[1] = x[1]^2 + x[2]^2 - 1
         return nothing
@@ -76,9 +75,14 @@ function check_inplace_quadratic()
             (0.0, [0.0]),
         )
         expected = ref_lag_hess!(objective, constraint!, x, σ, μ, p)
-        dense = zeros(2, 2)
+        dense = fill(NaN, 2, 2)
         instantiated.lag_h(dense, x, σ, μ, p)
         @test dense ≈ expected
+        packed = fill(NaN, 3)
+        instantiated.lag_h(packed, x, σ, μ, p)
+        @test packed ≈ [expected[1, 1], expected[2, 1], expected[2, 2]]
+        p[1] += 0.25
+        x .+= 0.1
     end
     return nothing
 end
@@ -110,10 +114,8 @@ end
 
 @testset "Enzyme Lagrangian Hessian" begin
     enzyme_ext = Base.get_extension(OptimizationBase, :OptimizationEnzymeExt)
-    @test enzyme_ext._lag_hessian_batch_width(4) ==
-        ((v"1.12" <= VERSION < v"1.13") ? 1 : 4)
-    @test enzyme_ext._lag_hessian_batch_width(17) ==
-        ((v"1.12" <= VERSION < v"1.13") ? 1 : 8)
+    @test enzyme_ext._hessian_batch_width(4) == 4
+    @test enzyme_ext._hessian_batch_width(17) == 8
 
     @testset "in-place clnlbeam N = $N" for N in (1:10..., 20, 40, 60)
         check_inplace_clnlbeam(N)
@@ -124,7 +126,7 @@ end
         check_inplace_quadratic()
     end
 
-    @testset "out-of-place quadratic n = $n" for n in (9, 17)
+    @testset "out-of-place quadratic n = $n" for n in (1, 7, 8, 9, 16, 17)
         check_oop_quadratic(n)
     end
 end

--- a/lib/OptimizationBase/test/AD/tests.jl
+++ b/lib/OptimizationBase/test/AD/tests.jl
@@ -1,6 +1,7 @@
 using Test
 
 @testset "OptimizationBase AD" begin
+    include("enzyme_lagrangian_hessian.jl")
     include("adtests.jl")
     include("dual_tolerant_tests.jl")
     include("cvxtest.jl")


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Generated Enzyme Lagrangian Hessians now use `BatchDuplicated` with a batch width capped at 8 on every Julia version. In-place and out-of-place evaluations share the batch loop, including zero-padded final batches. The Julia 1.12 row-wise fallback is removed.

The constraint contraction uses an explicit scalar loop instead of BLAS `dot`: restoring the BLAS contraction produces NaN Hessian entries under nested differentiation on Julia 1.12. The scalar contraction preserves conjugation of the multipliers. Tests cover dense and packed outputs, nonzero constraint curvature, zero and nonzero objective weights, changing parameters/multipliers, dimensions through 183, and full/partial batches.

The out-of-place Hessian regression is marked broken only on Julia 1.10 LTS, as requested, because Enzyme aborts the process on Zen 3/4 targets: https://github.com/EnzymeAD/Enzyme.jl/issues/3574. The marker does not execute the crashing code; in-place LTS tests and all out-of-place cases on Julia 1.11+ remain enabled. Production batching stays capped at eight on every version.

## Contraction regression: failing before / passing after

I ran the same committed 134-assertion regression in an isolated checkout with only `lagrangian_constraints` restored to `LinearAlgebra.dot`, and with the fix:

```bash
timeout 3600 ~/.juliaup/bin/julia +1.12 --startup-file=no --check-bounds=yes \
  --project=lib/OptimizationBase/test/AD \
  lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
```

```text
BLAS contraction restored:
Enzyme Lagrangian Hessian | 116 passed, 18 failed, 134 total | 2m02.7s
ERROR: LoadError: Some tests did not pass: 116 passed, 18 failed, 0 errored, 0 broken.

Scalar contraction:
Enzyme Lagrangian Hessian | 134 passed, 134 total | 2m09.7s
```

Both runs use width-8 batches and Enzyme 0.13.201. Separately, simply removing the old version fallback without fixing the contraction failed 30 of the original 82 assertions on Julia 1.12.

## LTS compiler regression: failing before / passing after

I reproduced the upstream LLVM verifier abort locally with Enzyme 0.13.203 and its GPUCompiler target explicitly set to `znver3` in an isolated diagnostic dependency checkout. Julia's `-C` option alone does not override that target. The same environment and command before and after the test gate:

```bash
ENZYME_DIAGNOSTIC_CPU=znver3 TMPDIR="$PWD/review-tmp" timeout 3600 \
  ~/.juliaup/bin/julia +1.10.12 --startup-file=no --check-bounds=auto \
  --project=enzyme-lts-gate-env \
  Optimization.jl/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
```

```text
Before: Instruction does not dominate all uses!
        LLVM ERROR: function failed verification (4)
        Process aborted, exit 134
After:  Enzyme Lagrangian Hessian | 62 passed, 6 broken, 68 total | 43.1s
        Exit 0
```

This quarantines the affected LTS tests; it does not fix the upstream compiler defect. The six markers replace 72 assertions across six dimensions on LTS. The standalone MWE and hardware/version comparisons are in https://github.com/EnzymeAD/Enzyme.jl/issues/3574. Hosted diagnostic evidence is at https://github.com/SciML/Optimization.jl/actions/runs/34698785686; diagnostics are kept separate in https://github.com/SciML/Optimization.jl/pull/1355.

## Local verification of the final test gate

Focused regression (same file as the compiler reproduction above):

```bash
TMPDIR="$PWD/review-tmp" timeout 3600 ~/.juliaup/bin/julia +1.11.9 --startup-file=no --check-bounds=yes --project=Optimization.jl/lib/OptimizationBase/test/AD Optimization.jl/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
TMPDIR="$PWD/review-tmp" timeout 3600 ~/.juliaup/bin/julia +1.12.7 --startup-file=no --check-bounds=auto --project=latest-enzyme-check Optimization.jl/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
TMPDIR="$PWD/review-tmp" timeout 3600 ~/.juliaup/bin/julia +1.13.0 --startup-file=no --check-bounds=auto --project=latest-enzyme-check Optimization.jl/lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl
```

```text
Julia 1.11.9: Enzyme Lagrangian Hessian | 134 passed / 134 total | 1m37.1s
Julia 1.12.7: Enzyme Lagrangian Hessian | 134 passed / 134 total | 1m27.9s
Julia 1.13.0: Enzyme Lagrangian Hessian | 134 passed / 134 total | 1m26.7s
```

The full LTS AD group uses the package's official harness and an unmodified Enzyme dependency:

```bash
cd Optimization.jl
OPTIMIZATION_TEST_GROUP=AD JULIA_PKG_PRECOMPILE_AUTO=0 TMPDIR="$PWD/../review-tmp" timeout 3600 ~/.juliaup/bin/julia +1.10.12 --project=lib/OptimizationBase -e 'using Pkg; Pkg.test(;coverage=true, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'
```

```text
Test Summary: | Pass  Broken  Total     Time
AD            |  866       6    872  9m43.5s
Testing OptimizationBase tests passed
Exit 0
```

The first full-suite attempt ended with SIGTERM before a test summary; the detached retry above completed successfully.

```bash
GROUP=QA JULIA_PKG_PRECOMPILE_AUTO=0 TMPDIR="$PWD/../review-tmp" timeout 3600 ~/.juliaup/bin/julia +1.12.7 --project=. -e 'using Pkg; Pkg.test()'
```

```text
QA | 21 passed / 21 total | 1m49.5s
Testing Optimization tests passed
```

Runic, `typos`, and `git diff --check` passed for the changed test file. No production code or assertion tolerances changed in the LTS gate commit.

## Earlier implementation validation

Before adding the LTS gate, the focused regression passed 134/134 on Julia 1.10.12 (native Zen 2), 1.11.9, 1.12.7, and released 1.13.0. The full OptimizationBase AD group passed 938/938 on Julia 1.12.7 (31m24.9s) and native Julia 1.10.12 (26m26.4s). OptimizationBase QA passed 20 tests with one pre-existing broken test.

## CI and remaining limitations

The LTS test gate is locally validated. The new commit's OptimizationBase AD jobs on LTS and stable Julia are still running: https://github.com/SciML/Optimization.jl/actions/runs/34746305607. This remains a draft until reviewed by @ChrisRackauckas.

I read the new ModelingToolkit downstream failure log: it is the same SymbolicAnalysis 0.5 versus ConvexOptimization 0.3 resolver conflict tracked separately, not an Enzyme test failure: https://github.com/SciML/Optimization.jl/actions/runs/34746305501/job/103694764247.

The separate ModelingToolkit resolver fix is https://github.com/SciML/Optimization.jl/pull/1353; its downstream CI passed 254 tests with one pre-existing broken test. The unrelated NeuralPDE failure reproduces on unmodified master and is tracked at https://github.com/SciML/NeuralPDE.jl/issues/1164. Neither change is included here.

The complete monorepo `Everything` suite, GPU paths, and 32-bit environments were not run locally. Documentation was not built; this changes no public API, docstrings, or documentation. Eight is the batch cap; optimality across objectives and machines has not been benchmarked.

Earlier investigation: https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session: 01a08039-86d4-7683-9601-30fd79501e27).
