### PR TITLE
Restore compatible LogExpFunctions and NOMAD ranges

### DIFF
--- a/lib/OptimizationBBO/Project.toml
+++ b/lib/OptimizationBBO/Project.toml
@@ -25,7 +25,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 [compat]
 BlackBoxOptim = "0.6.3"
 julia = "1.10"
-LogExpFunctions = "1"
+LogExpFunctions = "0.3.28, 1"
 OptimizationBase = "5.5.0"
 Pkg = "1"
 Random = "1.10"

--- a/lib/OptimizationEvolutionary/Project.toml
+++ b/lib/OptimizationEvolutionary/Project.toml
@@ -24,7 +24,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 [compat]
 SciMLTesting = "2.8"
 Evolutionary = "0.11"
-LogExpFunctions = "1"
+LogExpFunctions = "0.3.28, 1"
 OptimizationBase = "5.5.0"
 Pkg = "1"
 Random = "1.10"

--- a/lib/OptimizationNOMAD/Project.toml
+++ b/lib/OptimizationNOMAD/Project.toml
@@ -23,7 +23,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
 julia = "1.10"
-LogExpFunctions = "1"
+LogExpFunctions = "0.3.28, 1"
 NOMAD = "2.4.1"
 OptimizationBase = "5.5.0"
 Pkg = "1"


### PR DESCRIPTION
Ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed and why

Restore `LogExpFunctions = "0.3.28, 1"` for OptimizationBBO, OptimizationEvolutionary, and OptimizationNOMAD. The documentation environment installs all three packages together with Tracker; Tracker requires LogExpFunctions 0.3, so the major-1-only bounds make that environment unsatisfiable.

The resolver regression was introduced by https://github.com/SciML/Optimization.jl/commit/5f3ebeb5e1c200a62a33b9f78ba35f313965a278. This branch was rebased onto current master `c2d6a1d45e924d628fd1e75ae5e81868748644dd`. Its former NOMAD compatibility repair is no longer part of this diff because it was merged independently in https://github.com/SciML/Optimization.jl/pull/1333.

## Failing before

On clean current master with Julia 1.12.7, the documentation workflow's install command failed with exit code 1:

```console
$ julia +1.12 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
ERROR: Unsatisfiable requirements detected for package LogExpFunctions [2ab3a3ac]:
 ├─restricted to versions 1 by OptimizationNOMAD [2cab0595]
 └─restricted by compatibility requirements with Tracker [9f7883ad] to versions: 0.3.0 - 0.3.29 — no versions left
```

## Passing after

The same documentation install command completed with exit code 0. It resolved LogExpFunctions 0.3.29.

The current DiffEqFlux downstream environment was then activated with every root and `lib/*` Optimization project developed exactly as the reusable downstream workflow does. `Pkg.develop(...)` followed by `Pkg.update()` completed with exit code 0 and also resolved LogExpFunctions 0.3.29.

Relevant sublibrary tests on Julia 1.12.7:

```text
OptimizationBBO Core:          25 passed, 25 total
OptimizationEvolutionary Core: 55 passed, 55 total
OptimizationNOMAD Core:         4 passed, 4 total
OptimizationBBO QA:            20 passed, 1 pre-existing broken, 21 total
OptimizationEvolutionary QA:   19 passed, 2 pre-existing broken, 21 total
OptimizationNOMAD QA:          19 passed, 2 pre-existing broken, 21 total
```

Additional checks:

```text
julia +1.12 -m Runic --check .    exit 0
typos on the three changed files  exit 0
git diff --check                  exit 0
```

## Not verified

The full documentation build was attempted after the successful resolver step, but this machine's generated Pixi Python environment failed during installation with `Fatal Python error: init_fs_encoding`; the Documenter build is not claimed as passing locally. Full downstream test suites, GPU paths, and Julia pre were not run.

This only widens compatibility for an existing MIT-licensed dependency; it adds no dependency and changes no public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
