### PR TITLE
Test OptimizationBBO ZDT1 solution semantically

### DIFF
--- a/lib/OptimizationBBO/test/core_tests.jl
+++ b/lib/OptimizationBBO/test/core_tests.jl
@@ -211,8 +211,8 @@ using Random
 
             @test sol_3 ≠ nothing
             println("Solution for ZDT1: ", sol_3)
-            @test sol_3.objective[1] ≈ 0.273445 atol = 1.0e-3
-            @test sol_3.objective[2] ≈ 0.477079 atol = 1.0e-3
+            @test sol_3.objective == multi_obj_func_3(sol_3.u, nothing)
+            @test sol_3.objective[2] ≈ 1 - sqrt(sol_3.objective[1]) atol = 1.0e-3
         end
     end
 end


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

OptimizationBBO's ZDT1 test asserted one exact point chosen from the Pareto front. BlackBoxOptim's current epsilon-box archive selects a different, equally valid point, so the test now verifies the adapter contract and the solution quality: the reported objective must match the returned candidate, and that objective must lie on the analytical ZDT1 Pareto front.

## Root cause

This is not caused by Optimization.jl commit `5f3ebeb5e1c200a62a33b9f78ba35f313965a278`. Its parent fails identically with today's resolver.

The dependency boundary is BlackBoxOptim `0.6.9` to `0.6.10`. The exact source boundary is https://github.com/SciML/BlackBoxOptim.jl/commit/0e43c5fcb0bd75f1278e4aac2009ab39cce3001a: the epsilon-box frontier changed from an R-tree to a vector. Running the unchanged OptimizationBBO Core group against the immediately preceding BlackBoxOptim commit produced 25/25 passes and `(0.27364141361603134, 0.47689254104339984)`. Running it against `0e43c5fcb0bd75f1278e4aac2009ab39cce3001a` produced 23/25 passes and `(0.24493128111634194, 0.5051375150884184)`. Both points satisfy the ZDT1 front; only the archive-dependent point assertion was wrong.

## Failing before

On an unmodified clean `master` worktree:

```bash
OPTIMIZATION_TEST_GROUP=Core julia +1.11.9 --project=lib/OptimizationBBO \
  -e 'using Pkg; Pkg.test()'
```

```text
Solution for ZDT1: retcode: Default
u: [0.24493128111634194, 6.325227066413486e-6]
Final objective value: (0.24493128111634194, 0.5051375150884184)

Test Summary: | Pass  Fail  Total
Core          |   23     2     25
```

## Passing after

The same command with this change:

```text
Solution for ZDT1: retcode: Default
u: [0.24493128111634194, 6.325227066413486e-6]
Final objective value: (0.24493128111634194, 0.5051375150884184)

Test Summary: | Pass  Total  Time
Core          |   25     25  47.3s
Testing OptimizationBBO tests passed
```

Additional local verification:

- Julia 1.10.12 Core: 25/25 passed in 30.0 seconds.
- Julia 1.12.7 Core: 25/25 passed in 47.3 seconds.
- `OPTIMIZATION_TEST_GROUP=QA`: 20 passed, 1 pre-existing broken, 21 total.
- Runic `--check --diff`, `typos`, and `git diff --check`: clean.

This only changes test assertions, so no documentation build was required. The Julia prerelease channel was not run locally; it is an allowed-to-fail CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
