### PR TITLE
Cap AutoEnzyme Hessian batches at width 8

### DIFF
--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -96,16 +96,33 @@ end
 function_annotation(::Nothing) = Nothing
 function_annotation(::AutoEnzyme{<:Any, A}) where {A} = A
 
-function _onehot_cache(x)
-    ArrayInterface.fast_scalar_indexing(x) && return Enzyme.onehot(x)
-    return Tuple(
-        begin
-                dx = zero(x)
-                ArrayInterface.allowed_setindex!(dx, one(eltype(dx)), i)
-                dx
-            end for i in eachindex(x)
-    )
+const _HESSIAN_BATCH_CAP = 8
+
+_hessian_batch_width(n) = min(max(n, 1), _HESSIAN_BATCH_CAP)
+
+function _onehot_cache(x, batch_width)
+    n = length(x)
+    cache_length = cld(n, batch_width) * batch_width
+    if ArrayInterface.fast_scalar_indexing(x)
+        onehot = Enzyme.onehot(x)
+        return ntuple(i -> i <= n ? onehot[i] : zero(x), cache_length)
+    end
+    indices = eachindex(x)
+    return ntuple(cache_length) do i
+        dx = zero(x)
+        if i <= n
+            ArrayInterface.allowed_setindex!(dx, one(eltype(dx)), indices[i])
+        end
+        dx
+    end
 end
+
+_cache_batch(cache, first_index, ::Val{W}) where {W} =
+    ntuple(i -> cache[first_index + i - 1], Val(W))
+
+_batch_starts(cache, ::Val{W}) where {W} = firstindex(cache):W:lastindex(cache)
+
+_valid_batch_width(n, first_index, ::Val{W}) where {W} = min(W, n - first_index + 1)
 
 function _zero_cache!(x)
     fill!(x, zero(eltype(x)))
@@ -186,48 +203,62 @@ function OptimizationBase.instantiate_function(
 
     second_order_vdθ = if (h == true && f.hess === nothing) ||
             (fgh == true && f.fgh === nothing)
-        _onehot_cache(x)
+        _onehot_cache(x, _hessian_batch_width(length(x)))
     else
         nothing
     end
     second_order_vdbθ = if (fgh == true && f.fgh === nothing) ||
             (h == true && f.hess === nothing && f.hess_prototype === nothing)
-        Tuple(zero(x) for _ in eachindex(x))
+        ntuple(_ -> zero(x), length(second_order_vdθ))
     else
         nothing
     end
+    second_order_batch_width = Val(_hessian_batch_width(length(x)))
 
     if h == true && f.hess === nothing
         bθ = zero(x)
         vdbθ = if f.hess_prototype === nothing
             second_order_vdbθ
         else
-            Tuple(
-                ArrayInterface.restructure(x, copy(r)) for r in eachrow(f.hess_prototype)
-            )
+            prototype_rows = eachrow(f.hess_prototype)
+            ntuple(length(second_order_vdθ)) do i
+                i <= length(x) ?
+                ArrayInterface.restructure(x, copy(prototype_rows[i])) : zero(x)
+            end
         end
         hess_transfer_cache = ArrayInterface.fast_scalar_indexing(x) ? nothing : Vector{
                 eltype(x),
             }(undef, length(x))
 
         function hess(res, θ, p = p)
-            _zero_cache!(bθ)
-            for dbθ in vdbθ
-                _zero_cache!(dbθ)
-            end
+            for first_index in _batch_starts(second_order_vdθ, second_order_batch_width)
+                vdθ_batch = _cache_batch(
+                    second_order_vdθ, first_index, second_order_batch_width
+                )
+                vdbθ_batch = _cache_batch(vdbθ, first_index, second_order_batch_width)
+                _zero_cache!(bθ)
+                for dbθ in vdbθ_batch
+                    _zero_cache!(dbθ)
+                end
 
-            Enzyme.autodiff(
-                fmode,
-                inner_grad,
-                Const(rmode),
-                Enzyme.BatchDuplicated(θ, second_order_vdθ),
-                Enzyme.BatchDuplicatedNoNeed(bθ, vdbθ),
-                Const(f.f),
-                Const(p)
-            )
+                Enzyme.autodiff(
+                    fmode,
+                    inner_grad,
+                    Const(rmode),
+                    Enzyme.BatchDuplicated(θ, vdθ_batch),
+                    Enzyme.BatchDuplicatedNoNeed(bθ, vdbθ_batch),
+                    Const(f.f),
+                    Const(p)
+                )
 
-            for i in eachindex(θ)
-                _copy_hessian_row!(@view(res[i, :]), vdbθ[i], hess_transfer_cache)
+                for lane in 1:_valid_batch_width(
+                        length(θ), first_index, second_order_batch_width
+                    )
+                    i = first_index + lane - 1
+                    _copy_hessian_row!(
+                        @view(res[i, :]), vdbθ_batch[lane], hess_transfer_cache
+                    )
+                end
             end
             return
         end
@@ -243,25 +274,36 @@ function OptimizationBase.instantiate_function(
             }(undef, length(x))
 
         function fgh!(G, H, θ, p = p)
-            _zero_cache!(G)
-            for dbθ in second_order_vdbθ
-                _zero_cache!(dbθ)
-            end
-
-            Enzyme.autodiff(
-                fmode,
-                inner_grad,
-                Const(rmode),
-                Enzyme.BatchDuplicated(θ, second_order_vdθ),
-                Enzyme.BatchDuplicatedNoNeed(G, second_order_vdbθ),
-                Const(f.f),
-                Const(p)
-            )
-
-            for i in eachindex(θ)
-                _copy_hessian_row!(
-                    @view(H[i, :]), second_order_vdbθ[i], fgh_transfer_cache
+            for first_index in _batch_starts(second_order_vdθ, second_order_batch_width)
+                vdθ_batch = _cache_batch(
+                    second_order_vdθ, first_index, second_order_batch_width
                 )
+                vdbθ_batch = _cache_batch(
+                    second_order_vdbθ, first_index, second_order_batch_width
+                )
+                _zero_cache!(G)
+                for dbθ in vdbθ_batch
+                    _zero_cache!(dbθ)
+                end
+
+                Enzyme.autodiff(
+                    fmode,
+                    inner_grad,
+                    Const(rmode),
+                    Enzyme.BatchDuplicated(θ, vdθ_batch),
+                    Enzyme.BatchDuplicatedNoNeed(G, vdbθ_batch),
+                    Const(f.f),
+                    Const(p)
+                )
+
+                for lane in 1:_valid_batch_width(
+                        length(θ), first_index, second_order_batch_width
+                    )
+                    i = first_index + lane - 1
+                    _copy_hessian_row!(
+                        @view(H[i, :]), vdbθ_batch[lane], fgh_transfer_cache
+                    )
+                end
             end
             return
         end
@@ -606,27 +648,37 @@ function OptimizationBase.instantiate_function(
     end
 
     if h == true && f.hess === nothing
-        vdθ = Tuple((Array(r) for r in eachrow(I(length(x)) * one(eltype(x)))))
+        batch_width = _hessian_batch_width(length(x))
+        vdθ = _onehot_cache(x, batch_width)
         bθ = zeros(eltype(x), length(x))
-        vdbθ = Tuple(zeros(eltype(x), length(x)) for i in eachindex(x))
+        vdbθ = ntuple(_ -> zeros(eltype(x), length(x)), length(vdθ))
+        batch_width_value = Val(batch_width)
 
         function hess(θ, p = p)
-            Enzyme.make_zero!(bθ)
-            Enzyme.make_zero!.(vdbθ)
+            H = Matrix{eltype(θ)}(undef, length(θ), length(θ))
+            for first_index in _batch_starts(vdθ, batch_width_value)
+                vdθ_batch = _cache_batch(vdθ, first_index, batch_width_value)
+                vdbθ_batch = _cache_batch(vdbθ, first_index, batch_width_value)
+                Enzyme.make_zero!(bθ)
+                Enzyme.make_zero!.(vdbθ_batch)
 
-            Enzyme.autodiff(
-                fmode,
-                inner_grad,
-                Const(rmode),
-                Enzyme.BatchDuplicated(θ, vdθ),
-                Enzyme.BatchDuplicated(bθ, vdbθ),
-                Const(f.f),
-                Const(p)
-            )
+                Enzyme.autodiff(
+                    fmode,
+                    inner_grad,
+                    Const(rmode),
+                    Enzyme.BatchDuplicated(θ, vdθ_batch),
+                    Enzyme.BatchDuplicated(bθ, vdbθ_batch),
+                    Const(f.f),
+                    Const(p)
+                )
 
-            return reduce(
-                vcat, [reshape(vdbθ[i], (1, length(vdbθ[i]))) for i in eachindex(θ)]
-            )
+                for lane in 1:_valid_batch_width(
+                        length(θ), first_index, batch_width_value
+                    )
+                    H[first_index + lane - 1, :] .= vdbθ_batch[lane]
+                end
+            end
+            return H
         end
     elseif h == true
         hess = (θ, p = p) -> f.hess(θ, p)
@@ -635,28 +687,38 @@ function OptimizationBase.instantiate_function(
     end
 
     if fgh == true && f.fgh === nothing
-        vdθ_fgh = Tuple((Array(r) for r in eachrow(I(length(x)) * one(eltype(x)))))
-        vdbθ_fgh = Tuple(zeros(eltype(x), length(x)) for i in eachindex(x))
+        batch_width_fgh = _hessian_batch_width(length(x))
+        vdθ_fgh = _onehot_cache(x, batch_width_fgh)
+        vdbθ_fgh = ntuple(_ -> zeros(eltype(x), length(x)), length(vdθ_fgh))
         G_fgh = zeros(eltype(x), length(x))
         H_fgh = zeros(eltype(x), length(x), length(x))
+        batch_width_value_fgh = Val(batch_width_fgh)
 
         function fgh!(θ, p = p)
-            Enzyme.make_zero!(G_fgh)
             Enzyme.make_zero!(H_fgh)
-            Enzyme.make_zero!.(vdbθ_fgh)
+            for first_index in _batch_starts(vdθ_fgh, batch_width_value_fgh)
+                vdθ_batch = _cache_batch(vdθ_fgh, first_index, batch_width_value_fgh)
+                vdbθ_batch = _cache_batch(
+                    vdbθ_fgh, first_index, batch_width_value_fgh
+                )
+                Enzyme.make_zero!(G_fgh)
+                Enzyme.make_zero!.(vdbθ_batch)
 
-            Enzyme.autodiff(
-                fmode,
-                inner_grad,
-                Const(rmode),
-                Enzyme.BatchDuplicated(θ, vdθ_fgh),
-                Enzyme.BatchDuplicatedNoNeed(G_fgh, vdbθ_fgh),
-                Const(f.f),
-                Const(p)
-            )
+                Enzyme.autodiff(
+                    fmode,
+                    inner_grad,
+                    Const(rmode),
+                    Enzyme.BatchDuplicated(θ, vdθ_batch),
+                    Enzyme.BatchDuplicatedNoNeed(G_fgh, vdbθ_batch),
+                    Const(f.f),
+                    Const(p)
+                )
 
-            for i in eachindex(θ)
-                H_fgh[i, :] .= vdbθ_fgh[i]
+                for lane in 1:_valid_batch_width(
+                        length(θ), first_index, batch_width_value_fgh
+                    )
+                    H_fgh[first_index + lane - 1, :] .= vdbθ_batch[lane]
+                end
             end
             return G_fgh, H_fgh
         end

--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -223,7 +223,7 @@ function OptimizationBase.instantiate_function(
             prototype_rows = eachrow(f.hess_prototype)
             ntuple(length(second_order_vdθ)) do i
                 i <= length(x) ?
-                ArrayInterface.restructure(x, copy(prototype_rows[i])) : zero(x)
+                    ArrayInterface.restructure(x, copy(prototype_rows[i])) : zero(x)
             end
         end
         hess_transfer_cache = ArrayInterface.fast_scalar_indexing(x) ? nothing : Vector{

--- a/lib/OptimizationBase/test/AD/adtests.jl
+++ b/lib/OptimizationBase/test/AD/adtests.jl
@@ -1,4 +1,4 @@
-using OptimizationBase, Test, DifferentiationInterface, SparseArrays, Symbolics
+using OptimizationBase, Test, DifferentiationInterface, LinearAlgebra, SparseArrays, Symbolics
 using ADTypes, ForwardDiff, Zygote, ReverseDiff, FiniteDiff, Tracker
 using ModelingToolkit, Enzyme, Random, ComponentArrays, JLArrays
 
@@ -1533,4 +1533,35 @@ end
         @test y ≈ rosen(z)
         @test G ≈ gref
     end
+end
+
+@testset "Enzyme Hessian batch cap" begin
+    n = 17
+    x = collect(range(0.1, 1.7; length = n))
+    quartic(x, p = nothing) = sum(abs2(abs2(xi)) for xi in x)
+    expected_hessian = Matrix(Diagonal(12 .* x .^ 2))
+
+    enzyme_ext = Base.get_extension(OptimizationBase, :OptimizationEnzymeExt)
+    @test enzyme_ext._hessian_batch_width(4) == 4
+    @test enzyme_ext._hessian_batch_width(n) == 8
+
+    θ = ComponentVector(x = x)
+    optf = OptimizationBase.instantiate_function(
+        OptimizationFunction(quartic, AutoEnzyme()), θ, AutoEnzyme(), nothing;
+        h = true, fgh = true
+    )
+    gradient = similar(θ)
+    hessian = similar(expected_hessian)
+    optf.hess(hessian, θ)
+    @test hessian ≈ expected_hessian
+    optf.fgh(gradient, hessian, θ)
+    @test hessian ≈ expected_hessian
+
+    optf_oop = OptimizationBase.instantiate_function(
+        OptimizationFunction{false}(quartic, AutoEnzyme()), x, AutoEnzyme(), nothing;
+        h = true, fgh = true
+    )
+    @test optf_oop.hess(x) ≈ expected_hessian
+    _, hessian_oop = optf_oop.fgh(x)
+    @test hessian_oop ≈ expected_hessian
 end


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

OptimizationBase now computes generated AutoEnzyme objective Hessians and combined gradient/Hessian evaluations in batches capped at width 8. Inputs larger than 8 use repeated fixed-width calls, with zero tangent padding in the final batch so Enzyme compiles only one batch specialization.

The change covers in-place and out-of-place hess and fgh paths. It is internal and adds no public API. This addresses the compile-time behavior reduced at https://github.com/SciML/SciMLSensitivity.jl/issues/1427#issuecomment-5435813641.

## Failing before and passing after

The same 17-parameter regression exercises three batches, a one-lane remainder, ComponentVector input, and both in-place and out-of-place paths.

Clean upstream/master:

    Test Summary:            | Pass  Error  Total   Time
    Enzyme Hessian batch cap |    4      2      6  43.0s

Both errors are UndefVarError: _hessian_batch_width not defined in OptimizationEnzymeExt.

This branch:

    Test Summary:            | Pass  Total   Time
    Enzyme Hessian batch cap |    6      6  44.2s

## Verification

    GROUP=OptimizationBase_AD julia +1.12 --startup-file=no --project=. -e "using Pkg; Pkg.test()"
    AD | 801 passed / 801 total in 6m05.6s
    Testing OptimizationBase tests passed
    Testing Optimization tests passed

    GROUP=OptimizationBase_QA julia +1.12 --startup-file=no --project=. -e "using Pkg; Pkg.test()"
    QA | 20 passed, 1 pre-existing broken, 21 total in 1m15.0s
    Testing OptimizationBase tests passed
    Testing Optimization tests passed

    julia +1.12 --startup-file=no -m Runic --check lib/OptimizationBase/ext/OptimizationEnzymeExt.jl lib/OptimizationBase/test/AD/adtests.jl
    typos lib/OptimizationBase/ext/OptimizationEnzymeExt.jl lib/OptimizationBase/test/AD/adtests.jl
    git diff --check

All three checks exited successfully with no output.

A 252-parameter ComponentVector benchmark using the SciML-free loss from the issue reproducer gave identical H[1,1] = 0.0013142013:

    clean upstream/master, width 252: 342.898296608 seconds
    this branch, width 8:               42.558077407 seconds

This is an 8.1x first-call improvement through the same OptimizationBase API.

## Not verified

- GPU and Julia prerelease jobs were not run locally.
- GROUP=Everything was not run locally.
- Docs were not built because this changes neither documentation nor public API.
- Constraint Jacobian, constraint Hessian, and Lagrangian Hessian batching are unchanged and remain possible follow-up work.

The main review judgment is the fixed private default of 8. It follows the measured optimum in the standalone benchmark while leaving room for a later configurable public policy if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03f84-af17-7a90-955c-10b5d980e4da