### PR TITLE
Release OptimizationBase 5.5.2

### DIFF
--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.5.1"
+version = "5.5.2"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Releases #1331 — `Cap AutoEnzyme Hessian batches at width 8`.

Generated AutoEnzyme objective Hessians and combined gradient/Hessian evaluations are now computed in batches capped at width 8, with zero tangent padding in the final batch so Enzyme compiles a single batch specialisation. Covers the in-place and out-of-place `hess` and `fgh` paths.

**Patch**: the change is confined to `ext/OptimizationEnzymeExt.jl` internals — no exported or `public` name is added or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R