### PR TITLE
Fix OptimizationZygoteExt formatting

### DIFF
--- a/lib/OptimizationBase/ext/OptimizationZygoteExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationZygoteExt.jl
@@ -208,8 +208,8 @@ function OptimizationBase.instantiate_function(
     if cons !== nothing && f.cons_h === nothing && (cons_h == true || lag_h == true)
         prep_cons_hess = [
             prepare_hessian(
-                    cons_oop, soadtype, x, Constant(i), strict = Val(false)
-                )
+                cons_oop, soadtype, x, Constant(i), strict = Val(false)
+            )
                 for i in 1:num_cons
         ]
     else
@@ -587,8 +587,8 @@ function OptimizationBase.instantiate_function(
     if cons !== nothing && f.cons_h === nothing && cons_h == true
         prep_cons_hess = [
             prepare_hessian(
-                    cons_oop, soadtype, x, Constant(i), strict = Val(false)
-                )
+                cons_oop, soadtype, x, Constant(i), strict = Val(false)
+            )
                 for i in 1:num_cons
         ]
         colores = getfield.(prep_cons_hess, :coloring_result)


### PR DESCRIPTION
This applies the current Runic layout to two constraint-Hessian comprehensions in `OptimizationZygoteExt.jl`. The source behavior is unchanged; the focused mechanical change restores a clean whole-tree formatter check.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before, using the exact `master` blob with Runic 1.10:

```text
Runic --check --diff: exit 1
(two identical indentation diffs in OptimizationZygoteExt.jl)
```

Passing after:

```text
Runic 1.10 whole-tree --check: exit 0
OptimizationBase AD: 801 passed, 801 total
OptimizationBase QA: 20 passed, 1 pre-existing broken, 21 total
Optimization root QA: 21 passed, 21 total
typos on the changed file: exit 0
```

The formatting change was also checked against Runic 1.9 while isolating the version-specific drift. No docs build was run because this changes no documentation, docstrings, or public API. `GROUP=Everything` was not run; the targeted AD suite and both relevant QA suites cover the touched extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512