### PR TITLE
Document restored optimizer reexports

### DIFF
--- a/lib/OptimizationNLopt/src/OptimizationNLopt.jl
+++ b/lib/OptimizationNLopt/src/OptimizationNLopt.jl
@@ -8,6 +8,20 @@ using NLopt
 # NLopt's own solver-driving API (`optimize`, `lower_bounds!`, …) is not: Optimization.jl
 # drives the solver, and `optimize` collides with the other wrapped backends.
 using NLopt: Algorithm, Opt
+
+@doc """
+    Algorithm
+
+Enumeration of NLopt algorithm identifiers. Access the identifiers through the `NLopt`
+module, for example `NLopt.LD_LBFGS`.
+""" Algorithm
+
+@doc """
+    Opt(algorithm, n)
+
+Construct an NLopt optimizer for `n` variables using `algorithm`. The algorithm may be
+an [`Algorithm`](@ref) value or its symbol, such as `:LD_LBFGS`.
+""" Opt
 # Not re-exported: the optimization API comes from `Optimization`/`OptimizationBase`,
 # which the user loads directly. This package's public surface is its own solvers.
 using OptimizationBase

--- a/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
+++ b/lib/OptimizationOptimJL/src/OptimizationOptimJL.jl
@@ -9,6 +9,21 @@ using Optim
 using Optim: AcceleratedGradientDescent, BFGS, ConjugateGradient, Fminbox,
     GradientDescent, IPNewton, LBFGS, MomentumGradientDescent, NGMRES, NelderMead,
     Newton, NewtonTrustRegion, OACCEL, ParticleSwarm, SAMIN, SimulatedAnnealing
+
+@doc """
+    AcceleratedGradientDescent(; alphaguess, linesearch, manifold)
+
+Construct Optim's Nesterov-style accelerated gradient-descent method. The keyword
+arguments configure Optim's initial step estimate, line search, and manifold.
+""" AcceleratedGradientDescent
+
+@doc """
+    MomentumGradientDescent(; mu = 0.01, alphaguess, linesearch, manifold)
+
+Construct Optim's momentum gradient-descent method with momentum coefficient `mu`. The
+remaining keyword arguments configure Optim's initial step estimate, line search, and
+manifold.
+""" MomentumGradientDescent
 # Not re-exported: the optimization API comes from `Optimization`/`OptimizationBase`,
 # which the user loads directly. This package's public surface is its own solvers.
 using OptimizationBase

--- a/lib/OptimizationOptimisers/src/OptimizationOptimisers.jl
+++ b/lib/OptimizationOptimisers/src/OptimizationOptimisers.jl
@@ -12,6 +12,14 @@ using Optimisers: ADADelta, ADAGrad, ADAM, ADAMW, AMSGrad, AbstractRule, AccumGr
     AdaBelief, AdaDelta, AdaGrad, AdaMax, Adam, AdamW, ClipGrad, ClipNorm, Descent,
     Lion, Momentum, NADAM, NAdam, Nesterov, OADAM, OAdam, OptimiserChain, RADAM,
     RAdam, RMSProp, Rprop, SignDecay, WeightDecay
+
+@doc "Deprecated alias for [`AdaDelta`](@ref)." ADADelta
+@doc "Deprecated alias for [`AdaGrad`](@ref)." ADAGrad
+@doc "Deprecated alias for [`Adam`](@ref)." ADAM
+@doc "Deprecated alias for [`AdamW`](@ref)." ADAMW
+@doc "Deprecated alias for [`NAdam`](@ref)." NADAM
+@doc "Deprecated alias for [`OAdam`](@ref)." OADAM
+@doc "Deprecated alias for [`RAdam`](@ref)." RADAM
 # Not re-exported: the optimization API comes from `Optimization`/`OptimizationBase`,
 # which the user loads directly. This package's public surface is its own solvers.
 using OptimizationBase


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Document the optimizer bindings restored by the module-boundary cleanup in OptimizationOptimJL, OptimizationOptimisers, and OptimizationNLopt. Those names are established public reexports, but their local bindings had no docstrings, so all three sublibrary QA jobs failed the public-API documentation audit.

This preserves the existing API and fixes the documentation at the binding rather than excluding names from QA. There is no behavior, dependency, or export change.

## Verification

Failing before on upstream commit `3688dea3391e86715596574a2114e49e3d35138b`:

```text
OptimizationOptimJL:
Evaluated: isempty([:AcceleratedGradientDescent, :MomentumGradientDescent])
Quality Assurance | 53 passed, 1 failed, 1 broken, 55 total

OptimizationOptimisers:
Evaluated: isempty([:ADADelta, :ADAGrad, :ADAM, :ADAMW, :NADAM, :OADAM, :RADAM])
Quality Assurance | 79 passed, 1 failed, 1 broken, 81 total

OptimizationNLopt:
Evaluated: isempty([:Algorithm, :Opt])
Quality Assurance | 25 passed, 1 failed, 1 broken, 27 total
```

Passing after, using the same QA group in each sublibrary:

```text
OptimizationOptimJL   | 54 passed, 1 broken, 55 total
OptimizationOptimisers| 80 passed, 1 broken, 81 total
OptimizationNLopt     | 26 passed, 1 broken, 27 total
```

Commands:

```sh
OPTIMIZATION_TEST_GROUP=QA julia +release --project=lib/OptimizationOptimJL -e 'using Pkg; Pkg.test()'
OPTIMIZATION_TEST_GROUP=QA julia +release --project=lib/OptimizationOptimisers -e 'using Pkg; Pkg.test()'
OPTIMIZATION_TEST_GROUP=QA julia +release --project=lib/OptimizationNLopt -e 'using Pkg; Pkg.test()'
julia +release -m Runic --check lib/OptimizationOptimJL/src/OptimizationOptimJL.jl lib/OptimizationOptimisers/src/OptimizationOptimisers.jl lib/OptimizationNLopt/src/OptimizationNLopt.jl
git diff --name-only --diff-filter=ACMR | typos --file-list -
git diff --check
```

The three formatting/spelling/diff commands exited successfully.

Because this changes public docstrings, I also ran the complete documentation build from a clean generated CondaPkg environment and an isolated workspace-local Pixi/Rattler cache:

```sh
julia +release --project=docs -e 'using Pkg; Pkg.instantiate()'
julia +release --project=docs docs/make.jl
```

Documenter completed doctests, template expansion, cross-references, document checks, link checks, indices, and HTML rendering with exit code 0. It reported two existing HTTP 301 redirects and skipped deployment because this was a local build.

Hosted CI at `0de7f8bf3febc013d01ed0bee418b7e3cc7dead3` also completed all 54 checks owned by this patch successfully, including the three targeted QA jobs and the documentation build.

The four red downstream jobs are unchanged default-branch regressions, not failures introduced by this documentation-only diff:

- DiffEqFlux fails resolving the same LogExpFunctions/DistributionsAD constraints on this PR and on the latest default-branch IntegrationTest run.
- NeuralPDE NNPDE1 and NNPDE2 fail resolving the same CUDA/Tullio constraints on this PR and on the latest default-branch IntegrationTest run.
- ModelingToolkit reports the same 12 CasADi `create_array`/`abs2` errors on this PR and on the latest default-branch IntegrationTest run.

Those failures need separate root-cause fixes; combining them with this public-API documentation repair would obscure unrelated changes.

## Not verified

I did not rerun the sublibraries' Core groups locally because this patch only attaches docstrings and the relevant QA groups plus full docs build passed. Hosted Core and sublibrary checks passed. No GPU or credential-dependent path is involved in the changed code.

## Reviewer decision

The local docstrings intentionally describe the public constructors and deprecated aliases without changing ownership or export policy. Removing these restored exports instead would be a breaking API change.

## Links

- Failing workflow: https://github.com/SciML/Optimization.jl/actions/runs/33313329020
- OptimizationOptimJL QA failure: https://github.com/SciML/Optimization.jl/actions/runs/33313329020/job/99274524588
- OptimizationOptimisers QA failure: https://github.com/SciML/Optimization.jl/actions/runs/33313329020/job/99274524734
- OptimizationNLopt QA failure: https://github.com/SciML/Optimization.jl/actions/runs/33313329020/job/99274524785
- Passing hosted documentation build: https://github.com/SciML/Optimization.jl/actions/runs/33455319373
- Passing hosted OptimizationOptimJL QA: https://github.com/SciML/Optimization.jl/actions/runs/33455319432/job/99695217388
- Passing hosted OptimizationOptimisers QA: https://github.com/SciML/Optimization.jl/actions/runs/33455319432/job/99695217536
- Passing hosted OptimizationNLopt QA: https://github.com/SciML/Optimization.jl/actions/runs/33455319432/job/99695217362
- PR downstream run: https://github.com/SciML/Optimization.jl/actions/runs/33455319380
- Matching default-branch downstream run: https://github.com/SciML/Optimization.jl/actions/runs/33313328864
- Export-restoration commit: https://github.com/SciML/Optimization.jl/commit/f2134bd2c1c57f4782454f6ad53adc75d812abeb

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)
