### PR TITLE
Restore LogExpFunctions 0.3 compat for downstream resolution

### DIFF
--- a/lib/OptimizationBBO/Project.toml
+++ b/lib/OptimizationBBO/Project.toml
@@ -25,7 +25,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 [compat]
 BlackBoxOptim = "0.6.3"
 julia = "1.10"
-LogExpFunctions = "1"
+LogExpFunctions = "0.3.28, 1"
 OptimizationBase = "5.5.0"
 Pkg = "1"
 Random = "1.10"

--- a/lib/OptimizationEvolutionary/Project.toml
+++ b/lib/OptimizationEvolutionary/Project.toml
@@ -24,7 +24,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 [compat]
 SciMLTesting = "2.8"
 Evolutionary = "0.11"
-LogExpFunctions = "1"
+LogExpFunctions = "0.3.28, 1"
 OptimizationBase = "5.5.0"
 Pkg = "1"
 Random = "1.10"

--- a/lib/OptimizationNOMAD/Project.toml
+++ b/lib/OptimizationNOMAD/Project.toml
@@ -23,7 +23,7 @@ OptimizationBase = {path = "../OptimizationBase"}
 
 [compat]
 julia = "1.10"
-LogExpFunctions = "1"
+LogExpFunctions = "0.3.28, 1"
 NOMAD = "2.4.1"
 OptimizationBase = "5.5.0"
 Pkg = "1"


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Restore `LogExpFunctions = "0.3.28, 1"` in the weak-dependency compat entries for OptimizationBBO, OptimizationEvolutionary, and OptimizationNOMAD. Developing every Optimization sublibrary into DiffEqFlux's downstream test environment exposed the three `1`-only bounds: DiffEqFlux still tests DistributionsAD 0.6.58, whose StatsFuns 1.x constraint requires LogExpFunctions 0.3.x.

The lower bound was already tested before the compat cleanup, and this retains both that floor and LogExpFunctions 1.x. No dependency, source code, or public API changes.

## Failing before

On a clean checkout of `eab4badd8819cb7d5ac60de0e0acfa8352f50652`, this reproduction matched both hosted failures:

```sh
GROUP=PublicInterface JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_NUM_PRECOMPILE_TASKS=1 \
  julia +1.12.7 --project=downstream -e 'using Pkg; Pkg.activate("downstream"); projects = ["."; filter(project -> isfile(joinpath(project, "Project.toml")), readdir("lib"; join = true))]; Pkg.develop(map(project -> PackageSpec(path = project), projects)); Pkg.update(); Pkg.test()'
```

It exited 1 during resolution, before tests ran: OptimizationNOMAD (and the same bounds in OptimizationBBO and OptimizationEvolutionary) restricted LogExpFunctions to 1.x, while DiffEqFlux's DistributionsAD 0.6.58 restricted StatsFuns to at most 1.5.2 and therefore required LogExpFunctions 0.3.x.

The first hosted failure appeared when `7a4f2945d1f36c631afd17f9ddd55fdbfaa7b168` correctly enabled development of `.,lib/*`; that exposed the latent major-only bounds introduced by `5f3ebeb5e1c200a62a33b9f78ba35f313965a278`.

## Passing after

The same downstream develop/update/test path resolved successfully after this change. The outer environment retained LogExpFunctions 1.0.1 and StatsFuns 2.2.1; DiffEqFlux's test environment selected LogExpFunctions 0.3.29 and StatsFuns 1.5.2, then reported:

```text
Test Summary:     | Pass  Total     Time
Public interfaces |   45     45  7m32.3s
     Testing DiffEqFlux tests passed
```

The successful run used workspace-backed `TMPDIR` and `PIXI_CACHE_DIR`. Two earlier post-resolution attempts hit an unrelated corrupted shared Pixi installation (`libffi.so.8: file too short`) while precompiling Python-dependent sublibraries; neither was counted as a pass.

Additional local verification on Julia 1.12.7:

```text
GROUP=OptimizationBBO:              Core | 25 pass / 25 total
GROUP=OptimizationBBO_QA:           QA   | 20 pass / 1 existing broken / 21 total
GROUP=OptimizationEvolutionary:     Core | 55 pass / 55 total
GROUP=OptimizationEvolutionary_QA:  QA   | 19 pass / 2 existing broken / 21 total
GROUP=OptimizationNOMAD:            Core | 4 pass / 4 total
GROUP=OptimizationNOMAD_QA:         QA   | 19 pass / 2 existing broken / 21 total
GROUP=QA:                           QA   | 21 pass / 21 total
julia +1.12.7 -m Runic --check .:   passed
typos on all three changed files:   passed
git diff --check:                   passed
```

The complete downstream `GROUP=All` suite was not run locally; the targeted downstream discriminator and every affected sublibrary's complete Core and QA groups were run. Documentation was not built because this compat-only change touches no documentation or public API.

## Hosted CI

The final check snapshot has 53 successful checks, three failures, and one skipped matrix placeholder. The targeted DiffEqFlux `All` downstream job resolved and completed successfully. Its group summaries included Neural DE 241/241, Neural ODE MM 1/1, Second Order ODE 3/3, Newton Neural ODE 4/4, Collocation 50/50, Stiff Nested AD 3/3, and Public interfaces 45/45, ending with `Testing DiffEqFlux tests passed`.

The three red checks reproduce on current master and are independent of this three-line compat restoration:

- NeuralPDE NNPDE1 has the same CUDA/Tullio/Manifolds resolver contradiction on this PR and current master: CUDA 6 restricts Tullio to 0.1.0–0.3.5 while Manifolds requires Tullio 0.3.8–0.3.9. The extra Optimization dependency path shown on this PR does not change that empty intersection.
- NeuralPDE NNPDE2 has the same CUDA/Tullio/Manifolds contradiction on this PR and current master. The extra OptimizationSpeedMapping/OptimizationBase path shown on this PR is not causal.
- ModelingToolkit Optimization has the exact same `114 passed, 0 failed, 12 errored, 1 broken` result on this PR and current master: 11 errors are missing `create_array(::Type{CasADi.MX}, ...)` methods and the parameter-estimation error is missing `abs2(::CasADi.MX)`.

## Links

- Successful PR DiffEqFlux downstream: https://github.com/SciML/Optimization.jl/actions/runs/33468024663/job/99731820805
- Original default-branch DiffEqFlux resolver failure: https://github.com/SciML/Optimization.jl/actions/runs/33313328864/job/99262167760
- Matching earlier PR-run DiffEqFlux failure: https://github.com/SciML/Optimization.jl/actions/runs/33455319380/job/99693953600
- PR NNPDE1 failure: https://github.com/SciML/Optimization.jl/actions/runs/33468024663/job/99731821023
- Current-master NNPDE1 failure: https://github.com/SciML/Optimization.jl/actions/runs/33462562468/job/99715630632
- PR NNPDE2 failure: https://github.com/SciML/Optimization.jl/actions/runs/33468024663/job/99731820934
- Current-master NNPDE2 failure: https://github.com/SciML/Optimization.jl/actions/runs/33462562468/job/99715630794
- PR ModelingToolkit failure: https://github.com/SciML/Optimization.jl/actions/runs/33468024663/job/99731821003
- Current-master ModelingToolkit failure: https://github.com/SciML/Optimization.jl/actions/runs/33462562468/job/99715631000
- Commit that began developing all sublibraries downstream: https://github.com/SciML/Optimization.jl/commit/7a4f2945d1f36c631afd17f9ddd55fdbfaa7b168
- Compat cleanup that introduced the latent bounds: https://github.com/SciML/Optimization.jl/commit/5f3ebeb5e1c200a62a33b9f78ba35f313965a278
- Prior Tracker-specific investigation: https://github.com/SciML/Optimization.jl/pull/1329

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)
