### PR TITLE
Re-enable the SPD manifold test in OptimizationBase

### DIFF
--- a/lib/OptimizationBase/test/AD/cvxtest.jl
+++ b/lib/OptimizationBase/test/AD/cvxtest.jl
@@ -1,5 +1,5 @@
 using OptimizationBase, ForwardDiff, SymbolicAnalysis, LinearAlgebra,
-    Manifolds, OptimizationManopt, OptimizationLBFGSB
+    Manifolds, OptimizationManopt, OptimizationLBFGSB, Random
 
 function f(x, p = nothing)
     return exp(x[1]) + x[1]^2
@@ -34,22 +34,25 @@ prob = OptimizationProblem(
 @test res.cache.analysis_results.constraints[2].curvature ==
     SymbolicAnalysis.UnknownCurvature
 
-# Manifold optimization test temporarily skipped due to Manopt linesearch issue
-# producing NaN/Inf in SymmetricPositiveDefinite manifold optimization.
-# See GitHub issue for tracking.
-# m = 100
-# σ = 0.005
-# q = Matrix{Float64}(LinearAlgebra.I(5)) .+ 2.0
-#
-# M = SymmetricPositiveDefinite(5)
-# data2 = [exp(M, q, σ * rand(M; vector_at = q)) for i in 1:m];
-#
-# f(x, p = nothing) = sum(SymbolicAnalysis.distance(M, data2[i], x)^2 for i in 1:5)
-# optf = OptimizationFunction(f, OptimizationBase.AutoForwardDiff())
-# prob = OptimizationProblem(optf, data2[1]; manifold = M, structural_analysis = true)
-#
-# opt = OptimizationManopt.GradientDescentOptimizer()
-# @time sol = solve(prob, opt, maxiters = 100)
-# @test sol.objective < 1.0e-1
-# @test sol.cache.analysis_results.objective.curvature == SymbolicAnalysis.UnknownCurvature
-# @test sol.cache.analysis_results.objective.gcurvature == SymbolicAnalysis.GConvex
+# Manifold optimization on SymmetricPositiveDefinite (#1135). The optimization must not
+# start at one of the data points: at `x == data2[i]` the matrix inside the SPD `log` is
+# the identity, whose eigenvalues are all repeated, and ForwardDiff's `eigen` rule for
+# symmetric matrices divides by eigenvalue differences there. The resulting NaN gradient
+# was what made Manopt's linesearch fail intermittently. Start from the cluster centre.
+Random.seed!(1234)
+m = 100
+σ = 0.005
+q = Matrix{Float64}(LinearAlgebra.I(5)) .+ 2.0
+
+M = SymmetricPositiveDefinite(5)
+data2 = [exp(M, q, σ * rand(M; vector_at = q)) for i in 1:m];
+
+f(x, p = nothing) = sum(SymbolicAnalysis.distance(M, data2[i], x)^2 for i in 1:5)
+optf = OptimizationFunction(f, OptimizationBase.AutoForwardDiff())
+prob = OptimizationProblem(optf, q; manifold = M, structural_analysis = true)
+
+opt = OptimizationManopt.GradientDescentOptimizer()
+@time sol = solve(prob, opt, maxiters = 100)
+@test sol.objective < 1.0e-1
+@test sol.cache.analysis_results.objective.curvature == SymbolicAnalysis.UnknownCurvature
+@test sol.cache.analysis_results.objective.gcurvature == SymbolicAnalysis.GConvex


### PR DESCRIPTION
Fixes #1135.

## Diagnosis

The skipped test was not exposing a Manopt or Manifolds bug. It started the optimization at `data2[1]` while the objective sums the squared SPD distance to the first five data points, `data2[1]` included. For that term the matrix inside the SPD `log` is numerically the identity, so all its eigenvalues are repeated, and ForwardDiff's `eigen` rule for symmetric matrices divides by eigenvalue differences. Rounding noise usually leaves gaps of order 1e-16, but in roughly 9 of 4000 random datasets the gradient came out NaN. Manopt's linesearch then passed a non-finite tangent vector to `exp!`, which is the `chkuplofinite` error in the issue.

Checks that led here:

- current packages on Julia 1.12: 40 of 40 unseeded runs pass;
- the skip commit's environment on Julia 1.11 (Manifolds 0.10.23, Manopt 0.5.25, SymbolicAnalysis 0.3.9): passes;
- gradient at `x0 = data2[1]` over 4000 datasets: 9 non-finite, all from the self-distance term;
- gradient at `x0 = q` over 500 datasets and 60 full solves: none.

## Change

Re-enable the block, start from the cluster centre `q` instead of a data point, seed the RNG, and leave a comment explaining the degenerate point. The three original assertions are unchanged and pass in the AD test environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)