### PR TITLE
Cap AutoEnzyme Lagrangian Hessian batches at width 8

### DIFF
--- a/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
+++ b/lib/OptimizationBase/ext/OptimizationEnzymeExt.jl
@@ -139,6 +139,37 @@ function _copy_hessian_row!(dest, src, transfer_cache)
     return nothing
 end
 
+function _lag_hessian_rows!(
+        copy_row!, θ, σ, μ, p, fmode, rmode, vdθ, bθ, vdbθ,
+        batch_width, objective, cons
+    )
+    for first_index in _batch_starts(vdθ, batch_width)
+        vdθ_batch = _cache_batch(vdθ, first_index, batch_width)
+        vdbθ_batch = _cache_batch(vdbθ, first_index, batch_width)
+        _zero_cache!(bθ)
+        for dbθ in vdbθ_batch
+            _zero_cache!(dbθ)
+        end
+        Enzyme.autodiff(
+            fmode,
+            lag_grad,
+            Const(rmode),
+            Enzyme.BatchDuplicated(θ, vdθ_batch),
+            Enzyme.BatchDuplicatedNoNeed(bθ, vdbθ_batch),
+            Const(lagrangian),
+            Const(objective),
+            Const(cons),
+            Const(p),
+            Const(σ),
+            Const(μ)
+        )
+        for lane in 1:_valid_batch_width(length(θ), first_index, batch_width)
+            copy_row!(first_index + lane - 1, vdbθ_batch[lane])
+        end
+    end
+    return nothing
+end
+
 function OptimizationBase.instantiate_function(
         f::OptimizationFunction{true}, x,
         adtype::AutoEnzyme, p, num_cons = 0;
@@ -488,65 +519,45 @@ function OptimizationBase.instantiate_function(
     end
 
     if lag_h == true && f.lag_h === nothing && cons !== nothing
-        lag_vdθ = Tuple((Array(r) for r in eachrow(I(length(x)) * one(eltype(x)))))
-        lag_bθ = zeros(eltype(x), length(x))
+        lag_batch_width = _hessian_batch_width(length(x))
+        lag_vdθ = _onehot_cache(x, lag_batch_width)
+        lag_bθ = zero(x)
 
-        if f.hess_prototype === nothing
-            lag_vdbθ = Tuple(zeros(eltype(x), length(x)) for i in eachindex(x))
+        lag_vdbθ = if f.hess_prototype === nothing
+            ntuple(_ -> zero(x), length(lag_vdθ))
         else
-            #useless right now, looks like there is no way to tell Enzyme the sparsity pattern?
-            lag_vdbθ = Tuple((copy(r) for r in eachrow(f.hess_prototype)))
+            prototype_rows = eachrow(f.hess_prototype)
+            ntuple(length(lag_vdθ)) do i
+                i <= length(x) ?
+                    ArrayInterface.restructure(x, copy(prototype_rows[i])) : zero(x)
+            end
         end
+        lag_batch_width_value = Val(lag_batch_width)
+        lag_hess_transfer_cache = ArrayInterface.fast_scalar_indexing(x) ? nothing : Vector{
+                eltype(x),
+            }(undef, length(x))
 
         function lag_h!(h, θ, σ, μ, p = p)
-            Enzyme.make_zero!(lag_bθ)
-            Enzyme.make_zero!.(lag_vdbθ)
-
-            Enzyme.autodiff(
-                fmode,
-                lag_grad,
-                Const(rmode),
-                Enzyme.BatchDuplicated(θ, lag_vdθ),
-                Enzyme.BatchDuplicatedNoNeed(lag_bθ, lag_vdbθ),
-                Const(lagrangian),
-                Const(f.f),
-                Const(f.cons),
-                Const(p),
-                Const(σ),
-                Const(μ)
-            )
-            k = 0
-
-            for i in eachindex(θ)
-                vec_lagv = lag_vdbθ[i]
-                h[(k + 1):(k + i)] .= @view(vec_lagv[1:i])
-                k += i
+            copy_row! = function (i, row)
+                offset = (i - 1) * i ÷ 2
+                return h[(offset + 1):(offset + i)] .= @view(row[1:i])
             end
+            _lag_hessian_rows!(
+                copy_row!, θ, σ, μ, p, fmode, rmode, lag_vdθ, lag_bθ,
+                lag_vdbθ, lag_batch_width_value, f.f, f.cons
+            )
             return
         end
 
         function lag_h!(H::AbstractMatrix, θ, σ, μ, p = p)
             Enzyme.make_zero!(H)
-            Enzyme.make_zero!(lag_bθ)
-            Enzyme.make_zero!.(lag_vdbθ)
-
-            Enzyme.autodiff(
-                fmode,
-                lag_grad,
-                Const(rmode),
-                Enzyme.BatchDuplicated(θ, lag_vdθ),
-                Enzyme.BatchDuplicatedNoNeed(lag_bθ, lag_vdbθ),
-                Const(lagrangian),
-                Const(f.f),
-                Const(f.cons),
-                Const(p),
-                Const(σ),
-                Const(μ)
-            )
-
-            for i in eachindex(θ)
-                H[i, :] .= lag_vdbθ[i]
+            copy_row! = function (i, row)
+                return _copy_hessian_row!(@view(H[i, :]), row, lag_hess_transfer_cache)
             end
+            _lag_hessian_rows!(
+                copy_row!, θ, σ, μ, p, fmode, rmode, lag_vdθ, lag_bθ,
+                lag_vdbθ, lag_batch_width_value, f.f, f.cons
+            )
             return
         end
     elseif lag_h == true && cons !== nothing

--- a/lib/OptimizationBase/test/AD/adtests.jl
+++ b/lib/OptimizationBase/test/AD/adtests.jl
@@ -1564,4 +1564,37 @@ end
     @test optf_oop.hess(x) ≈ expected_hessian
     _, hessian_oop = optf_oop.fgh(x)
     @test hessian_oop ≈ expected_hessian
+
+    function quadratic_constraints!(res, x, p)
+        first_constraint = zero(eltype(x))
+        second_constraint = zero(eltype(x))
+        for i in eachindex(x)
+            first_constraint += x[i]^2
+            second_constraint += i * x[i]^2
+        end
+        res[1] = first_constraint
+        res[2] = second_constraint
+        return
+    end
+    σ = 0.7
+    μ = [0.2, -0.1]
+    expected_lagrangian_hessian =
+        σ .* expected_hessian .+ Matrix(Diagonal(2μ[1] .+ 2μ[2] .* eachindex(x)))
+    optf_lagrangian = OptimizationBase.instantiate_function(
+        OptimizationFunction(quartic, AutoEnzyme(); cons = quadratic_constraints!),
+        x, AutoEnzyme(), nothing, 2; lag_h = true
+    )
+    lagrangian_hessian = similar(expected_hessian)
+    optf_lagrangian.lag_h(lagrangian_hessian, x, σ, μ)
+    @test lagrangian_hessian ≈ expected_lagrangian_hessian
+    packed_lagrangian_hessian = Vector{eltype(x)}(undef, n * (n + 1) ÷ 2)
+    optf_lagrangian.lag_h(packed_lagrangian_hessian, x, σ, μ)
+    @test packed_lagrangian_hessian ≈ vcat(
+        [expected_lagrangian_hessian[i, 1:i] for i in 1:n]...
+    )
+    @test any(
+        getfield(optf_lagrangian.lag_h, i) isa Val{8}
+            for i in 1:fieldcount(typeof(optf_lagrangian.lag_h))
+    )
+
 end


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

OptimizationBase now computes generated `AutoEnzyme` Lagrangian Hessians in batches capped at width 8. Inputs larger than 8 use repeated fixed-width calls with zero tangent padding in the final batch, reusing the private policy and caches already used for objective Hessians.

OptimizationMOI requests `lag_h` for non-symbolic constrained problems. That path still differentiated every variable in one `BatchDuplicated`, so its LLVM compile time grew sharply with problem size even after objective Hessian batching was added in https://github.com/SciML/Optimization.jl/pull/1331. This change covers both dense and packed in-place Lagrangian Hessian outputs, is internal, and adds no public API or dependency.

## Failing before and passing after

The same 17-parameter regression test computes and checks dense and packed Lagrangian Hessians, then verifies that the generated closure captures the width-8 policy.

Clean `origin/master` with the test applied:

```text
Enzyme Hessian batch cap: Test Failed
Expression: any((getfield(optf_lagrangian.lag_h, i) isa Val{8} ...))
AD | 803 passed, 1 failed, 804 total in 9m06.1s
```

This branch:

```text
AD | 804 passed / 804 total in 8m46.5s
Testing OptimizationBase tests passed
Testing Optimization tests passed
```

A focused Julia 1.11.9 reproducer using the exact 183-variable, 120-constraint `clnlbeam` equations loaded the `OptimizationEnzymeExt` path and checked its result against the analytic Hessian:

```text
OptimizationBase 5.5.3, unbounded width: 207.182129194 seconds, max error 0.0
this branch, width 8:                  11.457115908 seconds, max error 0.0
```

The reduced three-backend benchmark sequence also discriminated the change:

```text
OptimizationBase 5.5.3: exit 124 after 1:00:14, last line `start backend=enzyme N=60`
this branch: exit 0 after 6:40.57, correct objectives through the benchmark's time gating
```

## Verification

```text
GROUP=OptimizationBase_AD julia +1.12.7 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
AD | 804 passed / 804 total in 8m46.5s

GROUP=QA julia +1.12.7 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
QA | 21 passed / 21 total in 1m17.7s
```

The Runic check, `typos` on both changed files, and `git diff --check` all exited successfully with no output.

The exact Julia 1.11.9 SciMLBenchmarks page completed against this source tree and the refreshed registered stack:

```text
timeout 14400 julia +1.11.9 --startup-file=no --threads=auto --project=. benchmark.jl benchmarks/OptimizationFrameworks/clnlbeam.jmd
exit 0 in 27:44.66, maximum RSS 4,833,580 KiB
```

The generated markdown had no error, exception, failure, unstable, or timeout markers. It produced a non-degenerate 576x384 plot with all six benchmark series, and every embedded objective/solution assertion passed.

## Not verified

- `GROUP=Everything`, GPU, and Julia prerelease jobs were not run locally.
- Docs were not built because this changes neither documentation nor public API.
- Constraint Jacobian and individual constraint-Hessian batching are unchanged.

The main review judgment is reusing the existing fixed private width of 8 for Lagrangian Hessians. A row-at-a-time implementation also avoids the wide batch, but the width-8 version retains batching and reduced the focused first call by about 18 times.

## Links

- Objective-Hessian batching prerequisite: https://github.com/SciML/Optimization.jl/pull/1331
- Source benchmark: https://github.com/SciML/SciMLBenchmarks.jl/blob/c2b5f0e46e3ba4418bb07f393949c6211f3750d8/benchmarks/OptimizationFrameworks/clnlbeam.jmd

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
