### PR TITLE
Scope Optimization libraries per downstream package

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,15 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: SciML, repo: DiffEqFlux.jl, group: All}
-          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE1}
-          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE2}
-          - {user: SciML, repo: ModelingToolkit.jl, group: Optimization}
+          - {user: SciML, repo: DiffEqFlux.jl, group: All, subdirs: ".,lib/OptimizationOptimJL,lib/OptimizationOptimisers"}
+          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE1, subdirs: ".,lib/OptimizationOptimJL,lib/OptimizationOptimisers"}
+          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE2, subdirs: ".,lib/OptimizationOptimJL,lib/OptimizationOptimisers"}
+          - {user: SciML, repo: ModelingToolkit.jl, group: Optimization, subdirs: ".,lib/*"}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
       group: "${{ matrix.package.group }}"
-      upstream-subdirs: ".,lib/*"
+      upstream-subdirs: "${{ matrix.package.subdirs }}"
       julia-version: "1"
     secrets: "inherit"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

Develop only the Optimization projects that DiffEqFlux and NeuralPDE actually exercise: the root package, `OptimizationOptimJL`, and `OptimizationOptimisers`. ModelingToolkit keeps the existing `.,lib/*` coverage.

Developing every one of the 27 solver libraries into every downstream test environment makes unrelated direct dependencies participate in resolution. This has made all three jobs fail before tests since `upstream-subdirs: ".,lib/*"` was added in https://github.com/SciML/Optimization.jl/pull/1326. The PR's own downstream jobs already showed the failures.

The narrower mapping does not revert to root-only coverage: searches of both downstream test trees show that `OptimizationOptimJL` and `OptimizationOptimisers` are the complete set of Optimization solver subpackages they import, and the full downstream groups below execute both local packages.

## Failing before

Clean checkouts at Optimization `eab4badd8819cb7d5ac60de0e0acfa8352f50652`, DiffEqFlux `1a0b5a7a6dbb2a07e2e30099ab9c27d4e663db5d`, and NeuralPDE `b37b171910a588efe230c0a9ef9c048d6e32eaed`, Julia 1.12.7, reproduced the reusable workflow's `Pkg.develop`/`Pkg.update`/`Pkg.test` sequence with `upstream_projects = [".", all lib/* projects]`.

- `GROUP=All` DiffEqFlux exited 1 before tests: local `OptimizationNOMAD 0.3.11` restricted `LogExpFunctions` to 1, while the DiffEqFlux test graph through `DistributionsAD`/`StatsFuns` restricted it to `0.3.2-0.3.29`; no versions remained.
- Both `GROUP=NNPDE1` and `GROUP=NNPDE2` exited 1 before tests: NeuralPDE's CUDA 6 test constraint restricted registered Tullio to `<=0.3.5`, while Manifolds pulled through local `OptimizationManopt 1.6.0` required Tullio `>=0.3.8`; no versions remained. The exact-manifest attempt first reported `MCMCChains 7` versus `OrderedCollections 2.0.1`, then the allowed re-resolution reached the irreducible Tullio conflict.

History isolates two layers:

- https://github.com/SciML/Optimization.jl/commit/7a4f2945d1f36c631afd17f9ddd55fdbfaa7b168 is the workflow-level first bad change: it added `upstream-subdirs: ".,lib/*"` to every matrix entry.
- https://github.com/SciML/Optimization.jl/commit/5f3ebeb5e1c200a62a33b9f78ba35f313965a278 changed OptimizationNOMAD's `LogExpFunctions` compat from `0.3.28` to `1`. A minimal environment using its parent resolves `OptimizationNOMAD 0.3.11 + DistributionsAD 0.6.58` with `LogExpFunctions 0.3.29`; the same environment at this commit fails with the LogExpFunctions graph above.
- https://github.com/SciML/NeuralPDE.jl/commit/c358df09a9ccc1cdc6d4cff30ff5987b69b18194 changed NeuralPDE's test CUDA compat to 6. Tullio master supports CUDA 6, but that compat has not been released; the latest registered release remains 0.3.9. Optimization's ManifoldsBase compat change in `5f3ebeb5...` is not required for this conflict: its parent reproduces the same Tullio graph.

## Passing after

For each clean downstream checkout, I ran the same reusable-workflow sequence with:

```julia
upstream_projects = [
    ".",
    "lib/OptimizationOptimJL",
    "lib/OptimizationOptimisers",
]
Pkg.develop(map(project -> PackageSpec(path = project), upstream_projects))
Pkg.update()
Pkg.test()
```

using `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager`, Julia 1.12.7, and the CI groups below:

```text
GROUP=All       DiffEqFlux: Testing DiffEqFlux tests passed
                              Neural DE | 241 passed
                                     CNF | 27 passed, 4 pre-existing broken
                       Newton Neural ODE | 4 passed
                         Stiff Nested AD | 3 passed
                       Public interfaces | 45 passed

GROUP=NNPDE1    NeuralPDE: Testing NeuralPDE tests passed
                            8 files, 23 assertions passed

GROUP=NNPDE2    NeuralPDE: Testing NeuralPDE tests passed
                            6 files, 12 assertions passed
```

The resolver selected `StatsFuns 1.5.3`, `LogExpFunctions 0.3.29`, and `OrderedCollections 1.8.2` where required, while keeping the three intended Optimization projects on the local checkout.

## Repository verification

```text
actionlint -no-color .github/workflows/Downstream.yml
exit 0

typos --format brief .github/workflows/Downstream.yml
exit 0

julia +1.12.7 --project=<Runic 1.10.0 env> -m Runic --check .
exit 0

git diff --check
exit 0

GROUP=QA julia +1.12.7 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
QA | 21 passed / 21 total
Testing Optimization tests passed
```

## Not verified here

- Documentation was not built because this changes only workflow configuration.
- GPU and `GROUP=Everything` were not run.
- ModelingToolkit's `.,lib/*` mapping is unchanged and was not re-run for this PR. Its current downstream test failures are the separate CasADi 1.3.0 regression already fixed in https://github.com/SciML/CasADi.jl/pull/42 and https://github.com/SciML/CasADi.jl/pull/43, with release 1.3.1 prepared in https://github.com/SciML/CasADi.jl/pull/44.

## Links

- Original workflow change: https://github.com/SciML/Optimization.jl/pull/1326
- PR 1326 DiffEqFlux failure: https://github.com/SciML/Optimization.jl/actions/runs/33002672473/job/98288262459
- PR 1326 NeuralPDE NNPDE1 failure: https://github.com/SciML/Optimization.jl/actions/runs/33002672473/job/98288262673
- PR 1326 NeuralPDE NNPDE2 failure: https://github.com/SciML/Optimization.jl/actions/runs/33002672473/job/98288262626
- Current DiffEqFlux failure: https://github.com/SciML/Optimization.jl/actions/runs/33931361476/job/101210435415
- Current NeuralPDE NNPDE1 failure: https://github.com/SciML/Optimization.jl/actions/runs/33931361476/job/101210435167
- Current NeuralPDE NNPDE2 failure: https://github.com/SciML/Optimization.jl/actions/runs/33931361476/job/101210435464
- Earlier merged-PR DiffEqFlux failure: https://github.com/SciML/Optimization.jl/actions/runs/33058271616/job/98470411953

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
