### PR TITLE
Release OptimizationNLopt 0.3.18

### DIFF
--- a/lib/OptimizationNLopt/Project.toml
+++ b/lib/OptimizationNLopt/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationNLopt"
 uuid = "4e6fcdb7-1186-4e1f-a706-475e75c168bb"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.17"
+version = "0.3.18"
 
 [deps]
 NLopt = "76087f3c-5699-56af-9a33-bf431cd00edd"


### PR DESCRIPTION
Bumps `OptimizationNLopt` 0.3.17 -> 0.3.18 (patch).

Source files changed since 0.3.17:
- `src/OptimizationNLopt.jl`

Commits:
- Drop stale [compat] majors older than one year (#1320)
- Release 5.9.0 (#1325)
- Support cached container-preserving AutoEnzyme Hessians (#1319)
- Release OptimizationBase 5.5.1 (#1327)
- Develop Optimization lib/* in Downstream CI (#1326)
- qa: use the shared reexport documentation policy (#1324)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
