### PR TITLE
Release OptimizationOptimJL 0.4.21

### DIFF
--- a/lib/OptimizationOptimJL/Project.toml
+++ b/lib/OptimizationOptimJL/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationOptimJL"
 uuid = "36348300-93cb-4f02-beb5-3c3902f8871e"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.4.20"
+version = "0.4.21"
 [deps]
 OptimizationBase = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"


### PR DESCRIPTION
Bumps `OptimizationOptimJL` 0.4.20 -> 0.4.21 (patch).

Source files changed since 0.4.20:
- `src/OptimizationOptimJL.jl`

Commits:
- Drop stale [compat] majors older than one year (#1320)
- Release 5.9.0 (#1325)
- Support cached container-preserving AutoEnzyme Hessians (#1319)
- Release OptimizationBase 5.5.1 (#1327)
- Develop Optimization lib/* in Downstream CI (#1326)
- qa: use the shared reexport documentation policy (#1324)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
