### PR TITLE
Release OptimizationOptimisers 0.3.24

### DIFF
--- a/lib/OptimizationOptimisers/Project.toml
+++ b/lib/OptimizationOptimisers/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationOptimisers"
 uuid = "42dfb2eb-d2b4-4451-abcd-913932933ac1"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
-version = "0.3.23"
+version = "0.3.24"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"


### PR DESCRIPTION
Bumps `OptimizationOptimisers` 0.3.23 -> 0.3.24 (patch).

Source files changed since 0.3.23:
- `src/OptimizationOptimisers.jl`

Commits:
- Drop stale [compat] majors older than one year (#1320)
- Release 5.9.0 (#1325)
- Support cached container-preserving AutoEnzyme Hessians (#1319)
- Release OptimizationBase 5.5.1 (#1327)
- Develop Optimization lib/* in Downstream CI (#1326)
- qa: use the shared reexport documentation policy (#1324)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
