### PR TITLE
Release OptimizationManopt 1.6.1

### DIFF
--- a/lib/OptimizationManopt/Project.toml
+++ b/lib/OptimizationManopt/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimizationManopt"
 uuid = "e57b7fff-7ee7-4550-b4f0-90e9476e9fb6"
 authors = ["Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>"]
-version = "1.6.0"
+version = "1.6.1"
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Bumps `OptimizationManopt` 1.6.0 -> 1.6.1 (patch).

Source files changed since 1.6.0:
- `src/OptimizationManopt.jl`

Commits:
- Drop stale [compat] majors older than one year (#1320)
- Release 5.9.0 (#1325)
- Support cached container-preserving AutoEnzyme Hessians (#1319)
- Release OptimizationBase 5.5.1 (#1327)
- Develop Optimization lib/* in Downstream CI (#1326)
- qa: use the shared reexport documentation policy (#1324)
- Cap AutoEnzyme Hessian batches at width 8 (#1331)
- Release OptimizationBase 5.5.2 (#1332)
- Fix downgrade compat floors for Ipopt, NLopt, and NOMAD sublibraries (#1333)
- Test OptimizationBBO ZDT1 solution semantically (#1330)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
