### PR TITLE
ConvexOptimization: lower l1/linf norm and exp/log objectives

### DIFF
--- a/lib/ConvexOptimization/src/ConvexOptimization.jl
+++ b/lib/ConvexOptimization/src/ConvexOptimization.jl
@@ -41,11 +41,12 @@ Conic backend: certify convexity with SymbolicAnalysis, lower the objective and
 each `ConeConstraint` to a MathOptInterface cone, and solve with
 `optimizer_constructor`.
 
-The objective may be affine or contain Euclidean-norm atoms, which are lowered
-through their epigraph: `minimize norm(A*u - b, 2)` introduces an epigraph
-variable `τ` with `(τ, A*u - b) ∈ SecondOrderCone` and minimizes `τ`. Keep a
-`norm` argument an array expression built from `u` (`A*u - b`, `u .- c`); a
-`Vector` literal of scalars scalarizes the atom away before it can be lowered.
+The objective may be affine or contain `norm` atoms, which are lowered through
+their epigraph: `minimize norm(A*u - b, 2)` introduces an epigraph variable `τ`
+with `(τ, A*u - b) ∈ SecondOrderCone` and minimizes `τ`. `p = 1` and `p = Inf`
+lower the same way to `NormOneCone` and `NormInfinityCone`. Keep a `norm`
+argument an array expression built from `u` (`A*u - b`, `u .- c`); a `Vector`
+literal of scalars scalarizes the atom away before it can be lowered.
 """
 struct ConvexMOI{O} <: AbstractConvexOptAlgorithm
     optimizer_constructor::O
@@ -263,6 +264,25 @@ end
 
 _norm_order(t) = (a = Symbolics.arguments(t); length(a) == 1 ? 2 : Symbolics.value(a[2]))
 
+# `norm(w, p) <= τ` is a cone membership of `(τ, w...)` for p ∈ {1, 2, Inf}; all
+# three share that row layout, so only the set differs. Other `p` have no
+# corresponding MOI cone.
+function _norm_cone(p, dim)
+    p isa Number || error(
+        "The order `p` of a `norm(w, p)` atom in the objective must be a constant " *
+            "1, 2 or Inf; got a non-constant expression. Route to a general " *
+            "OptimizationProblem/NLP solver."
+    )
+    p == 2 && return MOI.SecondOrderCone(dim)
+    p == 1 && return MOI.NormOneCone(dim)
+    isinf(p) && p > 0 && return MOI.NormInfinityCone(dim)
+    return error(
+        "This backend lowers `norm(w, p)` in the objective only for p = 1, 2 or " *
+            "Inf; got p = $p, which has no corresponding MathOptInterface cone. " *
+            "Reformulate or route to a general OptimizationProblem/NLP solver."
+    )
+end
+
 function _is_lowerable_atom(ex)
     Symbolics.iscall(ex) || return false
     return Symbolics.operation(ex) === LinearAlgebra.norm
@@ -314,18 +334,11 @@ function _epigraph_lower(obj)
     atoms = AtomCone[]
     subs = Dict{Any, Symbolics.Num}()
     for (k, t) in enumerate(nodes)
-        p = _norm_order(t)
-        (p isa Number && p == 2) || error(
-            "This backend lowers only the Euclidean norm `norm(w)` / `norm(w, 2)` " *
-                "in the objective; got `norm(w, p)` with p = " *
-                (p isa Number ? string(p) : "a non-constant expression") *
-                ", which is not a second-order cone. Reformulate or route to a " *
-                "general OptimizationProblem/NLP solver."
-        )
         w = _asvec(Symbolics.wrap(Symbolics.arguments(t)[1]))
+        set = _norm_cone(_norm_order(t), length(w) + 1)
         tau = variable(:τ, k)
         push!(taus, tau)
-        push!(atoms, AtomCone(Symbolics.Num[tau; w...], MOI.SecondOrderCone(length(w) + 1)))
+        push!(atoms, AtomCone(Symbolics.Num[tau; w...], set))
         subs[Symbolics.wrap(t)] = tau
     end
     return Symbolics.scalarize(Symbolics.substitute(obj, subs)), taus, atoms

--- a/lib/ConvexOptimization/src/ConvexOptimization.jl
+++ b/lib/ConvexOptimization/src/ConvexOptimization.jl
@@ -41,12 +41,18 @@ Conic backend: certify convexity with SymbolicAnalysis, lower the objective and
 each `ConeConstraint` to a MathOptInterface cone, and solve with
 `optimizer_constructor`.
 
-The objective may be affine or contain `norm` atoms, which are lowered through
-their epigraph: `minimize norm(A*u - b, 2)` introduces an epigraph variable `τ`
-with `(τ, A*u - b) ∈ SecondOrderCone` and minimizes `τ`. `p = 1` and `p = Inf`
-lower the same way to `NormOneCone` and `NormInfinityCone`. Keep a `norm`
-argument an array expression built from `u` (`A*u - b`, `u .- c`); a `Vector`
-literal of scalars scalarizes the atom away before it can be lowered.
+The objective may be affine or contain atoms that are lowered through their
+epigraph: `minimize norm(A*u - b, 2)` introduces an epigraph variable `τ` with
+`(τ, A*u - b) ∈ SecondOrderCone` and minimizes `τ`. Supported atoms are
+
+  - `norm(w, p)` for `p = 1, 2, Inf` (`NormOneCone`, `SecondOrderCone`,
+    `NormInfinityCone`), with `w` an array expression in `u`;
+  - `exp(w)` and `log(w)` for scalar affine `w` (`ExponentialCone`); `log` is
+    concave, so it is bounded below and must enter the objective negatively
+    (e.g. a `-log` barrier).
+
+Keep a `norm` argument an array expression built from `u` (`A*u - b`, `u .- c`);
+a `Vector` literal of scalars scalarizes the atom away before it can be lowered.
 """
 struct ConvexMOI{O} <: AbstractConvexOptAlgorithm
     optimizer_constructor::O
@@ -203,14 +209,18 @@ function lower_to_moi(prob::ConvexOptimizationProblem, alg::ConvexMOI, tr)
     )
     c = vec(_tofloat.(Ao))
     d = _tofloat(only(bo))
-    # `norm(w) <= τ` only bounds the atom from above, so replacing the atom by τ is
-    # valid only where the objective is nondecreasing in τ (nonincreasing for Max).
+    # An epigraph variable only bounds its atom on one side, so substituting it is
+    # valid only where the objective pushes it against that bound: a convex atom
+    # (`dir = +1`, bounded above) needs a nonnegative coefficient under MinSense, a
+    # concave one (`dir = -1`, bounded below) a nonpositive one; both flip for Max.
     sgn = prob.sense === SciMLBase.MaxSense ? -1.0 : 1.0
-    for k in eachindex(tr.taus)
-        sgn * c[n + k] >= 0 || error(
-            "Epigraph lowering of a `norm` atom is valid only when the objective is " *
-                "nondecreasing in it for MinSense (nonincreasing for MaxSense); got " *
-                "coefficient $(c[n + k]) for $(prob.sense). Route to a general " *
+    for (k, at) in enumerate(tr.atoms)
+        sgn * at.dir * c[n + k] >= 0 || error(
+            "Lowering an atom through its " *
+                (at.dir > 0 ? "epigraph" : "hypograph") * " is valid only when the " *
+                "objective is " * (at.dir > 0 ? "nondecreasing" : "nonincreasing") *
+                " in it for MinSense (reversed for MaxSense); got coefficient " *
+                "$(c[n + k]) for $(prob.sense). Route to a general " *
                 "OptimizationProblem/NLP solver."
         )
     end
@@ -247,6 +257,7 @@ implementation detail of the lowering and are deliberately kept out of
 struct AtomCone{S <: MOI.AbstractVectorSet}
     rows::Vector{Symbolics.Num}
     set::S
+    dir::Int   # +1: τ bounds a convex atom above; -1: τ bounds a concave atom below
 end
 
 function _trace_problem(prob)
@@ -283,9 +294,38 @@ function _norm_cone(p, dim)
     )
 end
 
+const LOWERABLE_ATOMS = (LinearAlgebra.norm, exp, log)
+
 function _is_lowerable_atom(ex)
     Symbolics.iscall(ex) || return false
-    return Symbolics.operation(ex) === LinearAlgebra.norm
+    return any(f -> Symbolics.operation(ex) === f, LOWERABLE_ATOMS)
+end
+
+# Each atom becomes `(rows, set, dir)`: `rows ∈ set` ties the epigraph variable
+# `tau` to the atom, and `dir` records which way it is bounded.
+#   convex  `f(w) <= tau`  (epigraph,  dir = +1)
+#   concave `f(w) >= tau`  (hypograph, dir = -1)
+# `MOI.ExponentialCone` is {(a, b, c) : b * exp(a / b) <= c, b > 0}, so
+# `exp(w) <= tau` is `(w, 1, tau)` and `log(w) >= tau` is `(tau, 1, w)`.
+function _atom_lowering(t, tau)
+    f = Symbolics.operation(t)
+    if f === LinearAlgebra.norm
+        w = _asvec(Symbolics.wrap(Symbolics.arguments(t)[1]))
+        return Symbolics.Num[tau; w...], _norm_cone(_norm_order(t), length(w) + 1), 1
+    end
+    w = _scalar_atom_arg(t, f)
+    f === exp && return Symbolics.Num[w, 1, tau], MOI.ExponentialCone(), 1
+    return Symbolics.Num[tau, 1, w], MOI.ExponentialCone(), -1
+end
+
+function _scalar_atom_arg(t, f)
+    a = _asvec(Symbolics.wrap(Symbolics.arguments(t)[1]))
+    length(a) == 1 || error(
+        "`$f` is lowered only for a scalar argument; got one of length $(length(a)). " *
+            "Write the elementwise form as a sum of scalar `$f` terms, or route to a " *
+            "general OptimizationProblem/NLP solver."
+    )
+    return only(a)
 end
 
 function _collect_atoms!(acc, ex)
@@ -334,11 +374,10 @@ function _epigraph_lower(obj)
     atoms = AtomCone[]
     subs = Dict{Any, Symbolics.Num}()
     for (k, t) in enumerate(nodes)
-        w = _asvec(Symbolics.wrap(Symbolics.arguments(t)[1]))
-        set = _norm_cone(_norm_order(t), length(w) + 1)
         tau = variable(:τ, k)
+        rows, set, dir = _atom_lowering(t, tau)
         push!(taus, tau)
-        push!(atoms, AtomCone(Symbolics.Num[tau; w...], set))
+        push!(atoms, AtomCone(rows, set, dir))
         subs[Symbolics.wrap(t)] = tau
     end
     return Symbolics.scalarize(Symbolics.substitute(obj, subs)), taus, atoms

--- a/lib/ConvexOptimization/test/core_tests.jl
+++ b/lib/ConvexOptimization/test/core_tests.jl
@@ -136,8 +136,8 @@ end
     prob2 = ConvexOptimizationProblem(optf2, [0.0])
     @test_throws Exception solve(prob2, ConvexMOI(Clarabel.Optimizer))
 
-    # only the Euclidean norm maps to a second-order cone.
-    optf3 = OptimizationFunction((u, p) -> norm(A * u - b, 1))
+    # p = 3 has no corresponding MOI cone (1, 2 and Inf do).
+    optf3 = OptimizationFunction((u, p) -> norm(A * u - b, 3))
     prob3 = ConvexOptimizationProblem(optf3, [0.0])
     @test_throws Exception solve(prob3, ConvexMOI(Clarabel.Optimizer))
 
@@ -145,4 +145,28 @@ end
     optf4 = OptimizationFunction((u, p) -> norm(u .^ 2 .- 1.0, 2))
     prob4 = ConvexOptimizationProblem(optf4, [0.5, 0.5])
     @test_throws Exception solve(prob4, ConvexMOI(Clarabel.Optimizer))
+end
+
+# l1 and linf norms lower to NormOneCone / NormInfinityCone, which share the
+# (tau, w...) row layout of the second-order cone.
+# Both minimize ||u - 1||_p subject to sum(u) == 1. Substituting u = (t, 1-t):
+#   p = 1:   |t-1| + |t|          -> 1   for any t in [0, 1]
+#   p = Inf: max(|t-1|, |t|)      -> 1/2 at t = 1/2
+@testset "l1 and linf norm objectives lower to their cones" begin
+    cons = [ConeConstraint((u, p) -> [u[1] + u[2] - 1.0], MOI.Zeros(1))]
+
+    optf1 = OptimizationFunction((u, p) -> norm(u .- 1.0, 1))
+    prob1 = ConvexOptimizationProblem(optf1, [0.5, 0.5]; constraints = cons)
+    sol1 = solve(prob1, ConvexMOI(Clarabel.Optimizer))
+    @test SciMLBase.successful_retcode(sol1.retcode)
+    @test isapprox(sol1.objective, 1.0; atol = 1.0e-6)
+    @test isapprox(sum(sol1.u), 1.0; atol = 1.0e-6)
+    @test length(sol1.dual) == 1        # epigraph cone stays out of the user duals
+
+    optfi = OptimizationFunction((u, p) -> norm(u .- 1.0, Inf))
+    probi = ConvexOptimizationProblem(optfi, [0.5, 0.5]; constraints = cons)
+    soli = solve(probi, ConvexMOI(Clarabel.Optimizer))
+    @test SciMLBase.successful_retcode(soli.retcode)
+    @test isapprox(soli.objective, 0.5; atol = 1.0e-6)
+    @test isapprox(soli.u, [0.5, 0.5]; atol = 1.0e-6)
 end

--- a/lib/ConvexOptimization/test/core_tests.jl
+++ b/lib/ConvexOptimization/test/core_tests.jl
@@ -170,3 +170,36 @@ end
     @test isapprox(soli.objective, 0.5; atol = 1.0e-6)
     @test isapprox(soli.u, [0.5, 0.5]; atol = 1.0e-6)
 end
+
+# exp and log lower to the exponential cone. exp is convex so it is bounded
+# above (epigraph); log is concave so it is bounded below (hypograph) and must
+# enter the objective negatively.
+@testset "exp and log objectives lower to the exponential cone" begin
+    # minimize exp(u1) + u2  s.t.  u1 == 1, u2 == 0  ->  e
+    optfe = OptimizationFunction((u, p) -> exp(u[1]) + u[2])
+    conse = [ConeConstraint((u, p) -> [u[1] - 1.0, u[2]], MOI.Zeros(2))]
+    sole = solve(
+        ConvexOptimizationProblem(optfe, [0.0, 0.0]; constraints = conse),
+        ConvexMOI(Clarabel.Optimizer)
+    )
+    @test SciMLBase.successful_retcode(sole.retcode)
+    @test isapprox(sole.objective, exp(1); atol = 1.0e-6)
+
+    # log barrier: minimize -log(u1) s.t. u1 == 2  ->  -log(2)
+    optfl = OptimizationFunction((u, p) -> -log(u[1]))
+    consl = [ConeConstraint((u, p) -> [u[1] - 2.0], MOI.Zeros(1))]
+    soll = solve(
+        ConvexOptimizationProblem(optfl, [1.0]; constraints = consl),
+        ConvexMOI(Clarabel.Optimizer)
+    )
+    @test SciMLBase.successful_retcode(soll.retcode)
+    @test isapprox(soll.objective, -log(2); atol = 1.0e-6)
+    @test length(soll.dual) == 1        # epigraph cone stays out of the user duals
+
+    # a bare `log` objective is concave: minimizing it is not a convex program.
+    optfb = OptimizationFunction((u, p) -> log(u[1]))
+    @test_throws Exception solve(
+        ConvexOptimizationProblem(optfb, [1.0]; constraints = consl),
+        ConvexMOI(Clarabel.Optimizer)
+    )
+end


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Follow-on to #1347, which landed Euclidean-norm epigraph lowering. These two commits were written against that branch but pushed after it merged, so they never made it to master — this reopens them, rebased onto current master and re-verified. Two self-contained commits, reviewable individually.

## 1. `norm(w, 1)` and `norm(w, Inf)`

`norm(w, p) <= τ` is membership of `(τ, w...)` in a cone, and MOI's `NormOneCone` / `NormInfinityCone` share the second-order cone's row layout — so only the set differs, and the old `p != 2` rejection becomes a lookup. Covers lasso- and Chebyshev-style objectives. `p = 3` still errors (no corresponding MOI cone).

## 2. `exp(w)` and `log(w)` → `ExponentialCone`

This one generalizes the machinery. An epigraph variable only bounds its atom **one way**, so each atom now records a direction:

| | bound | `dir` | atoms |
|---|---|---|---|
| convex | `f(w) <= τ` (epigraph) | `+1` | `norm`, `exp` |
| concave | `f(w) >= τ` (hypograph) | `-1` | `log` |

and the validity guard becomes "the objective must push `τ` against that bound": nonnegative coefficient for an epigraph atom under `MinSense`, nonpositive for a hypograph one, both reversed for `MaxSense`. `norm` keeps its previous behaviour as the `dir = +1` case. This is the shape future atoms (PSD) slot into without a rewrite.

`MOI.ExponentialCone` is `{(a,b,c) : b*exp(a/b) <= c, b > 0}`, so `exp(w) <= τ` is `(w, 1, τ)` and `log(w) >= τ` is `(τ, 1, w)`. **Both orientations were checked directly against Clarabel before being wired in** (`e = 2.718282`, `-log(2) = -0.693147`), rather than taken from the docs. Makes log-barrier objectives such as `-log(u[1])` expressible.

## Rejections (loud, never silent)

| case | why |
|---|---|
| `log(u[1])` as a bare objective | concave atom entering positively |
| `-norm(...)`, or `MaxSense` with a `norm` | convex atom entering negatively |
| `norm(w, 3)` | no corresponding MOI cone |
| elementwise `exp.(u)` / `log.(u)` | only scalar arguments are lowered |
| `norm(u.^2 .- 1, 2)` | argument not affine |

## Verification (run locally, on top of current master)

- **46/46 tests pass**, including every pre-existing testset unchanged.
- New: l1/linf cones (7), exp/log cone (6).
- Analytic optima hit exactly: l1 → `1.0` and linf → `0.5` at `u = (1/2, 1/2)` subject to `sum(u) == 1`; `exp` → `e`; `-log` → `-log(2)`.
- Duals stay 1:1 with the user's constraints — epigraph cones are never in `sol.dual`.
- Runic clean, `typos` clean.

Part of SciML/SymbolicAnalysis.jl#121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)