### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "OptimizationOptimJL,ForwardDiff"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,49 @@
+using Optimization, OptimizationOptimJL, ForwardDiff, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+rosenbrock(x, p) = (p[1] - x[1])^2 + p[2] * (x[2] - x[1]^2)^2
+x0 = zeros(2)
+p = (1.0, 100.0)
+
+# =============================================================================
+# Problem construction
+# =============================================================================
+
+SUITE["construct"] = BenchmarkGroup()
+
+SUITE["construct"]["optfunction_ad"] = @benchmarkable OptimizationFunction(
+    $rosenbrock, Optimization.AutoForwardDiff()
+)
+SUITE["construct"]["optproblem"] = @benchmarkable OptimizationProblem(
+    $(OptimizationFunction(rosenbrock, Optimization.AutoForwardDiff())), $x0, $p
+)
+
+optf = OptimizationFunction(rosenbrock, Optimization.AutoForwardDiff())
+prob = OptimizationProblem(optf, x0, p)
+
+# =============================================================================
+# Solves
+# =============================================================================
+
+SUITE["solve"] = BenchmarkGroup()
+
+SUITE["solve"]["BFGS"] = @benchmarkable solve($prob, BFGS())
+SUITE["solve"]["LBFGS"] = @benchmarkable solve($prob, LBFGS())
+SUITE["solve"]["NelderMead"] = @benchmarkable solve(
+    $(OptimizationProblem(rosenbrock, x0, p)), NelderMead()
+)
+
+# =============================================================================
+# Larger problem
+# =============================================================================
+
+SUITE["larger"] = BenchmarkGroup()
+
+rosenbrock_n(x, p) = sum(i -> (1.0 - x[i])^2 + 100.0 * (x[i + 1] - x[i]^2)^2, 1:99)
+optf_n = OptimizationFunction(rosenbrock_n, Optimization.AutoForwardDiff())
+prob_n = OptimizationProblem(optf_n, zeros(100), nothing)
+
+SUITE["larger"]["BFGS_100d"] = @benchmarkable solve(
+    $prob_n, BFGS(); maxiters = 100
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~27s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~27s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md