### PR TITLE
Allow SymbolicAnalysis 0.5 in ConvexOptimization

### DIFF
--- a/lib/ConvexOptimization/Project.toml
+++ b/lib/ConvexOptimization/Project.toml
@@ -20,7 +20,7 @@ MathOptInterface = "1.45"
 Reexport = "1.2"
 SciMLBase = "3.36"
 SparseArrays = "1.10"
-SymbolicAnalysis = "0.3"
+SymbolicAnalysis = "0.3, 0.5"
 Symbolics = "7"
 julia = "1.10"
 


### PR DESCRIPTION
Allow ConvexOptimization to use SymbolicAnalysis 0.5 while retaining 0.3 support. OptimizationBase requires 0.5, so developing both subpackages currently fails before ModelingToolkit downstream tests can run. This is a compatibility-only change; the existing `analyze` signature and documented result fields used here remain available in 0.5.1.

Fixes https://github.com/SciML/Optimization.jl/issues/1352.

Please ignore this PR until reviewed by @ChrisRackauckas.

Verification on Julia 1.12.7:

```sh
JULIA_PKG_PRECOMPILE_AUTO=0 julia --project=resolver-repro -e 'using Pkg; Pkg.develop([PackageSpec(path="lib/OptimizationBase"), PackageSpec(path="lib/ConvexOptimization")]); Pkg.status(); println("JOINT RESOLUTION PASSED"); ENV["OPTIMIZATION_TEST_GROUP"]="Core"; Pkg.test("ConvexOptimization")'
```

Before (clean master and introducing commit, fresh local environment):

```text
ERROR: Unsatisfiable requirements detected for package SymbolicAnalysis [4297ee4d]:
 SymbolicAnalysis [4297ee4d] log:
 ├─possible versions are: 0.1.0 - 0.5.1 or uninstalled
 ├─restricted to versions 0.5 by OptimizationBase [bca83a33], leaving only versions: 0.5.0 - 0.5.1 or uninstalled
 └─restricted to versions 0.3 by ConvexOptimization [e7fa4f8d] — no versions left
```

After (same pair-development operation, fresh local environment, followed by the existing complete Core group):

```text
[4297ee4d] SymbolicAnalysis v0.5.1
Test Summary: | Pass  Total     Time
Core          |  196    196  4m47.2s
Testing ConvexOptimization tests passed
JOINT RESOLUTION PASSED
```

`typos lib/ConvexOptimization/Project.toml` and `git diff --check` both exited 0. No Julia source changed, so Runic does not apply. This subpackage defines only Core and has no QA group. No documentation/public API changed, so no docs build was run. The optional pre-existing Convex.jl cross-check was unavailable; all analytic Core assertions ran. The full ModelingToolkit downstream suite, other Julia versions, and allowed-to-fail/GPU jobs were not run locally.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local parent session ID: 01a08039-86d4-7683-9601-30fd79501e27).
