### PR TITLE
Route solve through the problem's problem_type when wrapping solutions

### DIFF
--- a/lib/OptimizationBase/Project.toml
+++ b/lib/OptimizationBase/Project.toml
@@ -1,6 +1,6 @@
 name = "OptimizationBase"
 uuid = "bca83a33-5cc9-4baa-983d-23429ab6bcbb"
-version = "5.5.3"
+version = "5.6.0"
 authors = ["Vaibhav Dixit <vaibhavyashdixit@gmail.com> and contributors"]
 
 [deps]
@@ -59,7 +59,7 @@ Mooncake = "0.4.138, 0.5"
 PrecompileTools = "1.2.1"
 ReverseDiff = "1.14"
 SafeTestsets = ">= 0.0.1"
-SciMLBase = "3"
+SciMLBase = "3.54"
 SciMLLogging = "2"
 SciMLTesting = "2.8"
 SparseArrays = "1.10"

--- a/lib/OptimizationBase/src/solve.jl
+++ b/lib/OptimizationBase/src/solve.jl
@@ -61,7 +61,7 @@ sol = solve(prob, Optim.BFGS(); maxiters = 100)
 function solve(
         prob::SciMLBase.OptimizationProblem, args...; sensealg = nothing,
         u0 = nothing, p = nothing, wrap = Val(true), kwargs...
-    )::SciMLBase.AbstractOptimizationSolution
+    )::Union{SciMLBase.AbstractOptimizationSolution, SciMLBase.AbstractPDESolution}
     if sensealg === nothing && haskey(prob.kwargs, :sensealg)
         sensealg = prob.kwargs[:sensealg]
     end
@@ -69,6 +69,8 @@ function solve(
     u0 = u0 !== nothing ? u0 : prob.u0
     p = p !== nothing ? p : prob.p
     return if wrap isa Val{true}
+        # `OptimizationSolution` does not carry its problem, so route the discretization
+        # metadata (see `SciMLBase.problem_type`) explicitly.
         wrap_sol(
             solve_up(
                 prob,
@@ -78,7 +80,8 @@ function solve(
                 args...;
                 originator = SciMLBase.ChainRulesOriginator(),
                 kwargs...
-            )
+            ),
+            SciMLBase.problem_type(prob)
         )
     else
         solve_up(

--- a/lib/OptimizationBase/test/solve_internals_test.jl
+++ b/lib/OptimizationBase/test/solve_internals_test.jl
@@ -329,3 +329,30 @@ end
     @test SciMLBase.successful_retcode(sol)
     @test _mock_ncalls[] == 1
 end
+
+# ============================================================
+# Solution wrapping through `problem_type`
+# ============================================================
+
+struct MockDiscretizationMetadata <: SciMLBase.AbstractDiscretizationMetadata{Val(false)} end
+struct MockPDESolution{S} <:
+    SciMLBase.AbstractPDENoTimeSolution{Float64, 1, S, MockDiscretizationMetadata}
+    original_sol::S
+    disc_data::MockDiscretizationMetadata
+end
+function SciMLBase.PDENoTimeSolution(sol, metadata::MockDiscretizationMetadata)
+    return MockPDESolution(sol, metadata)
+end
+
+@testset "solve wraps the solution through the problem's problem_type" begin
+    f = OptimizationFunction((u, p) -> sum(abs2, u))
+    metadata = MockDiscretizationMetadata()
+    prob = OptimizationProblem(f, [1.0, 2.0]; problem_type = metadata)
+    wrapped = solve(prob, MockSolver())
+    @test wrapped isa MockPDESolution
+    @test wrapped.original_sol isa SciMLBase.OptimizationSolution
+    @test wrapped.disc_data === metadata
+    @test solve(prob, MockSolver(); wrap = Val(false)) isa SciMLBase.OptimizationSolution
+    @test solve(OptimizationProblem(f, [1.0, 2.0]), MockSolver()) isa
+        SciMLBase.OptimizationSolution
+end


### PR DESCRIPTION
> **Note:** please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`solve(::OptimizationProblem)` called the one-argument `wrap_sol(sol)`, which looks up `sol.prob`. `OptimizationSolution` has no `prob` field, so discretization metadata could never wrap an optimization solution into a PDE solution. The NeuralPDE parser rewrite (https://github.com/SciML/NeuralPDE.jl/issues/1161) lowers a `PDESystem` to an `OptimizationProblem` and needs `solve` to return a `PDENoTimeSolution`, exactly as MethodOfLines gets its `PDETimeSeriesSolution` from `ODEProblem`.

Two changes in `lib/OptimizationBase/src/solve.jl`:
- pass `SciMLBase.problem_type(prob)` to `wrap_sol` explicitly (it is `nothing` for ordinary problems, which leaves the solution unchanged);
- widen the return annotation to `Union{AbstractOptimizationSolution, AbstractPDESolution}`.

Depends on https://github.com/SciML/SciMLBase.jl/pull/1600 (the `problem_type` slot on `OptimizationProblem`); the OptimizationBase compat is bumped to `SciMLBase = "3.54"` so CI will only resolve once that is released. Minor version bump of OptimizationBase (5.5.3 → 5.6.0).

## Verification

New testset in `test/solve_internals_test.jl` using the existing `MockSolver` and a mock `AbstractDiscretizationMetadata`. Run with SciMLBase#1600 dev'd, Julia 1.11.9:

```
Test Summary:   | Pass  Total  Time
solve internals |   44     44  4.5s
```

Without the change (registered SciMLBase 3.53.3 accepts the unknown keyword but never wraps), the full Core group shows the new testset failing and everything else passing:

```
solve wraps the solution through the problem's problem_type: Test Failed ... Expression: wrapped isa MockPDESolution
Core | 56  1  2  59
```

## Not verified

The other test groups (AD, QA) and the solver sub-packages were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)

https://claude.ai/code/session_01WYPUXLxE9jVu2jXLFRd8ax
