### PR TITLE
Diagnose the Enzyme LTS Hessian compiler failure

### DIFF
--- a/.diagnostics/.gitignore
+++ b/.diagnostics/.gitignore
@@ -1,0 +1,3 @@
+tmp/
+result.log
+enzyme/Manifest.toml

--- a/.diagnostics/enzyme/Project.toml
+++ b/.diagnostics/enzyme/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Enzyme = "=0.13.203"
+julia = "1.10"

--- a/.diagnostics/enzyme/barrier.jl
+++ b/.diagnostics/enzyme/barrier.jl
@@ -1,0 +1,10 @@
+function barrier_calls(ex)
+    ex isa Expr || return ex
+    ex.head == :function && return ex
+    if ex.head == :call && ex.args[1] === :check_case
+        return Expr(:call, GlobalRef(Base, :invokelatest), ex.args...)
+    end
+    return Expr(ex.head, map(barrier_calls, ex.args)...)
+end
+
+include(barrier_calls, joinpath(@__DIR__, "standalone.jl"))

--- a/.diagnostics/enzyme/fixture.jl
+++ b/.diagnostics/enzyme/fixture.jl
@@ -1,0 +1,6 @@
+using InteractiveUtils, Enzyme
+
+versioninfo()
+println("Enzyme ", pkgversion(Enzyme), "; CPU ", Sys.CPU_NAME)
+flush(stdout)
+include(joinpath(ENV["OPTIMIZATION_SUBJECT"], "lib/OptimizationBase/test/AD/enzyme_lagrangian_hessian.jl"))

--- a/.diagnostics/enzyme/standalone.jl
+++ b/.diagnostics/enzyme/standalone.jl
@@ -1,0 +1,77 @@
+using Enzyme, InteractiveUtils, Test
+
+versioninfo()
+println("Enzyme ", pkgversion(Enzyme), "; CPU ", Sys.CPU_NAME)
+flush(stdout)
+
+function contraction(λ, res)
+    value = zero(promote_type(eltype(λ), eltype(res)))
+    for i in eachindex(λ, res)
+        value += conj(λ[i]) * res[i]
+    end
+    return value
+end
+
+function lagrangian(x, objective, cons, p, λ, σ)
+    return σ * objective(x, p) + contraction(λ, cons(x, p))
+end
+
+function gradient!(mode, x, dx, f)
+    Enzyme.make_zero!(dx)
+    Enzyme.autodiff(mode, Const(f), Active, Duplicated(x, dx))
+    return nothing
+end
+
+function check_case(n, ::Val{W}, σ) where {W}
+    objective(x, p) = sum(abs2(abs2(xi)) for xi in x) + p[1] * sum(x)
+    cons(x, p) = [sum(abs2, x) - 1, x[1] * x[min(2, n)] - p[2]]
+    f = (; f = objective, cons)
+    x = collect(range(0.1; step = 0.05, length = n))
+    p = [0.3, -0.2]
+    μ = [1.25, -0.75]
+    lag = x -> lagrangian(x, f.f, f.cons, p, μ, σ)
+    dx = zero(x)
+    expected_gradient = σ .* (4 .* x .^ 3 .+ p[1]) .+ 2 .* μ[1] .* x
+    expected_gradient[1] += μ[2] * x[min(2, n)]
+    expected_gradient[min(2, n)] += μ[2] * x[1]
+    H = zeros(n, n)
+    expected = zeros(n, n)
+    for i in 1:n
+        expected[i, i] = 12 * σ * x[i]^2 + 2 * μ[1]
+    end
+    expected[1, min(2, n)] += μ[2]
+    expected[min(2, n), 1] += μ[2]
+    tangents = ntuple(_ -> zero(x), Val(W))
+    for first_index in 1:W:n
+        seeds = ntuple(Val(W)) do j
+            seed = zero(x)
+            first_index + j - 1 <= n && (seed[first_index + j - 1] = 1)
+            seed
+        end
+        Enzyme.make_zero!(dx)
+        Enzyme.make_zero!.(tangents)
+        Enzyme.autodiff(
+            Forward, gradient!, Const(Reverse), BatchDuplicated(x, seeds),
+            BatchDuplicated(dx, tangents), Const(lag)
+        )
+        for j in 1:min(W, n - first_index + 1)
+            H[:, first_index + j - 1] .= tangents[j]
+        end
+    end
+    @test H ≈ expected
+    println("HESSIAN PASS")
+    flush(stdout)
+    gradient!(Reverse, x, dx, lag)
+    @test dx ≈ expected_gradient
+    println("REVERSE PASS")
+    flush(stdout)
+    return nothing
+end
+
+@testset "Standalone Enzyme Hessian" begin
+    for width in (1, 7, 8), n in (1, 7, 8, 9, 16, 17), σ in (1.0, 0.0, 2.5)
+        println("BEGIN n=", n, " width=", width, " sigma=", σ)
+        flush(stdout)
+        check_case(n, Val(width), σ)
+    end
+end

--- a/.github/workflows/enzyme-isolation.yml
+++ b/.github/workflows/enzyme-isolation.yml
@@ -17,6 +17,8 @@ jobs:
           - julia: '1.10.12'
             mode: standalone
           - julia: '1.10.12'
+            mode: barrier
+          - julia: '1.10.12'
             mode: fixture
           - julia: '1.10.12'
             mode: official
@@ -47,6 +49,7 @@ jobs:
             julia --project=.diagnostics/enzyme -e 'using Pkg; Pkg.develop(path=joinpath(ENV["OPTIMIZATION_SUBJECT"], "lib/OptimizationBase")); Pkg.add(["ChainRulesCore", "ForwardDiff"])'
           fi
       - name: Reproduce
+        shell: bash
         run: |
           lscpu
           if [ "$DIAGNOSTIC_MODE" = official ]; then

--- a/.github/workflows/enzyme-isolation.yml
+++ b/.github/workflows/enzyme-isolation.yml
@@ -1,0 +1,63 @@
+name: Enzyme LTS isolation
+on:
+  pull_request:
+    paths:
+      - ".diagnostics/**"
+      - ".github/workflows/enzyme-isolation.yml"
+permissions:
+  contents: read
+jobs:
+  isolate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - julia: '1.10.12'
+            mode: standalone
+          - julia: '1.10.12'
+            mode: fixture
+          - julia: '1.10.12'
+            mode: official
+          - julia: '1.13.0'
+            mode: standalone
+    env:
+      JULIA_NUM_THREADS: '1'
+      JULIA_PKG_PRECOMPILE_AUTO: '1'
+      OPTIMIZATION_SUBJECT: ${{ github.workspace }}/subject
+      TMPDIR: ${{ github.workspace }}/.diagnostics/tmp
+      DIAGNOSTIC_MODE: ${{ matrix.mode }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: SciML/Optimization.jl
+          ref: 9a8a5c75f94b16048cff400bb1eed091f49c937f
+          path: subject
+      - run: mkdir -p "$TMPDIR"
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.julia }}
+      - name: Prepare isolated environment
+        if: matrix.mode != 'official'
+        run: |
+          julia --project=.diagnostics/enzyme -e 'using Pkg; Pkg.instantiate()'
+          if [ "$DIAGNOSTIC_MODE" = fixture ]; then
+            julia --project=.diagnostics/enzyme -e 'using Pkg; Pkg.develop(path=joinpath(ENV["OPTIMIZATION_SUBJECT"], "lib/OptimizationBase")); Pkg.add(["ChainRulesCore", "ForwardDiff"])'
+          fi
+      - name: Reproduce
+        run: |
+          lscpu
+          if [ "$DIAGNOSTIC_MODE" = official ]; then
+            OPTIMIZATION_TEST_GROUP=AD julia --project="$OPTIMIZATION_SUBJECT/lib/OptimizationBase" -e 'using Pkg, InteractiveUtils; versioninfo(); Pkg.test(;coverage=true, julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)' 2>&1 | tee .diagnostics/result.log
+          else
+            julia --startup-file=no --check-bounds=auto --compiled-modules=yes --depwarn=yes --code-coverage=@"$PWD" --project=.diagnostics/enzyme ".diagnostics/enzyme/$DIAGNOSTIC_MODE.jl" 2>&1 | tee .diagnostics/result.log
+          fi
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: enzyme-${{ matrix.julia }}-${{ matrix.mode }}
+          path: |
+            .diagnostics/result.log
+            .diagnostics/enzyme/Manifest.toml


### PR DESCRIPTION
The LTS job in https://github.com/SciML/Optimization.jl/pull/1328 repeatedly fails with an LLVM verifier error while the same regression passes locally. This temporary diagnostic workflow checks out the exact failing commit, then compares an Enzyme-only analytic Hessian test, the unchanged regression, and the official AD command on hosted runners. It prints CPU details and uploads logs/manifests; Julia 1.13.0 provides a stable-version control.

**Diagnostic PR: keep as a draft; do not merge. Ignore until reviewed by @ChrisRackauckas.**

## Local verification

Commands were run from the shared workspace. `latest-enzyme-lts` is the isolated environment with Enzyme 0.13.203, ChainRulesCore, ForwardDiff, and the subject OptimizationBase checkout.

```bash
GROUP=QA JULIA_PKG_PRECOMPILE_AUTO=0 TMPDIR="$PWD/review-tmp" timeout 3600 ~/.juliaup/bin/julia +1.12 --project=enzyme-hosted-diagnostic -e 'using Pkg; Pkg.test()'
TMPDIR="$PWD/review-tmp" timeout 3600 ~/.juliaup/bin/julia +1.10.12 --startup-file=no --check-bounds=auto --compiled-modules=yes --depwarn=yes --code-coverage=@"$PWD/enzyme-hosted-diagnostic" --project=enzyme-hosted-diagnostic/.diagnostics/enzyme enzyme-hosted-diagnostic/.diagnostics/enzyme/standalone.jl
OPTIMIZATION_SUBJECT="$PWD/Optimization.jl" TMPDIR="$PWD/review-tmp" timeout 3600 ~/.juliaup/bin/julia +1.10.12 --startup-file=no --check-bounds=auto --compiled-modules=yes --depwarn=yes --code-coverage=@"$PWD/Optimization.jl" --project=latest-enzyme-lts enzyme-hosted-diagnostic/.diagnostics/enzyme/fixture.jl
```

```text
QA:                        21/21 passed, 1m07.5s
Standalone Enzyme Hessian: 108/108 passed, 4.0s
Enzyme Lagrangian Hessian: 134/134 passed, 1m23.5s
```

Runic, actionlint, typos, and `git diff --check` passed. The full subject AD suite also passed locally with automatic precompilation enabled: 938/938 in 6m34.4s. Its 238 comparable dependency versions match the failing CI run.

## Isolation findings and diagnostic correction

The Enzyme-only test reproduced the identical LLVM verifier failure on Julia 1.10.12 / AMD EPYC 7763 (Zen 3), without importing any SciML package. Julia 1.13.0 passed 108/108 on the same CPU model. The unchanged LTS regression passed 134/134 on an Intel Xeon 6973P-C runner. Locally, configuring Enzyme's target as `znver3` reproduces the exact `%623` / `%tempphi.sroa.156.1` dominance failure from the subject CI log. Ordinary reverse differentiation of the reduced objective passes; the nested Hessian path is being reduced further.

The first diagnostic wrapper incorrectly let `tee` hide Julia's abort, producing a green job. The workflow now explicitly selects `shell: bash`, which enables `pipefail`. Local regression evidence using a failing command in the same pipeline:

```text
before FAIL: A failing Julia-command substitute was reported as successful exit: 0
after PASS: failure propagated, exit: 1
```

The original standalone test is retained. A separate driver adds an `invokelatest` barrier to identify the first failing case; that driver passes all 108 local assertions on the native CPU. First-run green job status must not be interpreted as successful execution of the crashing LTS standalone case.

The earlier Julia `-C` checks do not override GPUCompiler's physical-host target used by Enzyme. Target control for the local reproducer uses a separate Enzyme checkout; no dependency source changes are part of this PR. The obsolete fork-hosted run was cancelled after the SciML run reproduced the failure.

GPU and full downstream suites were not run locally; no production code, assertions, or tolerances are changed. Enzyme is already a repository test dependency and is MIT-licensed; this only pins it in the isolated diagnostic environment. Documentation was not built locally because no documentation or public API changes.

Links:
- Subject PR: https://github.com/SciML/Optimization.jl/pull/1328
- Enzyme-only LTS failure (read log, not first-run green status): https://github.com/SciML/Optimization.jl/actions/runs/34698110920/job/103564998784
- Repeated LTS failure: https://github.com/SciML/Optimization.jl/actions/runs/34684825479/job/103554419756

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session: 01a08039-86d4-7683-9601-30fd79501e27).
